### PR TITLE
Added a new Constraint: ParametrizedBaseAttr

### DIFF
--- a/src/main/scala/scair/AttrParser.scala
+++ b/src/main/scala/scair/AttrParser.scala
@@ -61,12 +61,13 @@ object AttrParser {
 
   def IntegerAttrP[$: P]: P[IntegerAttr] =
     P(
-      (IntDataP ~ (":" ~ IntegerTypeP).?).map((x, y) =>
+      (IntDataP ~ (":" ~ (IntegerTypeP | IndexTypeP)).?).map((x, y) =>
         IntegerAttr(
           x,
           y match {
-            case Some(a) => a
-            case None    => I64
+            case x: Some[IntegerType]    => x.get
+            case y: Some[IndexType.type] => y.get
+            case None                    => I64
           }
         )
       )

--- a/src/main/scala/scair/dialects/Builtin.scala
+++ b/src/main/scala/scair/dialects/Builtin.scala
@@ -103,8 +103,10 @@ case class IntegerType(val width: IntData, val sign: Signedness)
 // INTEGER ATTRIBUTE //
 ///////////////////////
 
-case class IntegerAttr(val value: IntData, val typ: IntegerType)
-    extends ParametrizedAttribute("builtin.integer_attr", Seq(value, typ)) {
+case class IntegerAttr(
+    val value: IntData,
+    val typ: IntegerType | IndexType.type
+) extends ParametrizedAttribute("builtin.integer_attr", Seq(value, typ)) {
 
   def this(value: IntData) = this(value, I64)
 
@@ -233,14 +235,14 @@ case class SymbolRefAttr(
     s"@${rootRef.data}::${nestedRefs.data.map(x => s"@${x.data}").mkString("::")}"
 }
 
-//////////////////////////////
+////////////////////
 // DenseArrayAttr //
-//////////////////////////////
+////////////////////
 
 case class DenseArrayAttr(
     val typ: Attribute,
     val data: Seq[Attribute]
-) extends ParametrizedAttribute("builtin.dense") {
+) extends ParametrizedAttribute("builtin.dense", typ +: data) {
 
   override def custom_verify(): Unit =
     typ match {


### PR DESCRIPTION
ParametrizedBaseAttr verifies the base class (PT) of a given Parametrized Attribute and checks that all parameters within it conform to the given type (CT) 

```Scala
class ParametrizedBaseAttr[
    PT <: ParametrizedAttribute: ClassTag,
    CT <: Attribute: ClassTag
]() extends IRDLConstraint {
```