### PR TITLE
More constraint sugar

### DIFF
--- a/src/main/scala/scair/clair/IRElements.scala
+++ b/src/main/scala/scair/clair/IRElements.scala
@@ -95,6 +95,7 @@ case class DialectDef(
 import scair.ir._
 import scair.dialects.builtin._
 import scair.scairdl.constraints._
+import scair.scairdl.constraints.attr2constraint
   """ +
     (operations.map(_.print(0)) ++ attributes.map(_.print(0)))
       .mkString("\n") + s"""

--- a/src/test/scala/scair/dialects/irdl/Constraints.scala
+++ b/src/test/scala/scair/dialects/irdl/Constraints.scala
@@ -132,7 +132,7 @@ class ConstraintsTest extends AnyFlatSpec with BeforeAndAfter {
     val attr4 = IndexType
     val attr5 = ArrayAttribute(Seq(IndexType, attr4, I64))
 
-    val or_constraint = AnyOf(Seq(attr1, attr2, attr3, attr4, attr5))
+    val or_constraint = attr1 || attr2 || attr3 || attr4 || attr5
 
     or_constraint.verify(that_attr, constraint_ctx)
   }
@@ -147,12 +147,12 @@ class ConstraintsTest extends AnyFlatSpec with BeforeAndAfter {
     val attr3 = Float32Type
     val attr4 = IndexType
 
-    val or_constraint = AnyOf(Seq(attr1, attr2, attr3, attr4))
+    val or_constraint = attr1 || attr2 || attr3 || attr4
 
     val exception = intercept[Exception](
       or_constraint.verify(that_attr, constraint_ctx)
     ).getMessage shouldBe
-      "builtin.array_attr does not match any of List(EqualAttr(IntegerAttr(IntData(5),IntegerType(IntData(32),Signless))), EqualAttr(IntegerAttr(IntData(6),IntegerType(IntData(32),Signless))), EqualAttr(Float32Type), EqualAttr(IndexType))\n"
+      "builtin.array_attr does not match IntegerAttr(IntData(5),IntegerType(IntData(32),Signless)) || IntegerAttr(IntData(6),IntegerType(IntData(32),Signless)) || Float32Type || IndexType\n"
   }
 
   "OR Constraint Test 3" should "verify AnyOf constraint (should PASS)" in {
@@ -166,7 +166,7 @@ class ConstraintsTest extends AnyFlatSpec with BeforeAndAfter {
     val attrcnst1 = BaseAttr[IndexType.type]()
     val attrcnst2 = EqualAttr(ArrayAttribute(Seq(IndexType, IndexType, I64)))
 
-    val or_constraint = AnyOf(Seq(attr1, attr2, attr3, attrcnst1, attrcnst2))
+    val or_constraint = attr1 || attr2 || attr3 || attrcnst1 || attrcnst2
 
     or_constraint.verify(that_attr, constraint_ctx)
   }
@@ -184,7 +184,7 @@ class ConstraintsTest extends AnyFlatSpec with BeforeAndAfter {
     val attrcnst2 = EqualAttr(ArrayAttribute(Seq(IndexType, I32, I64)))
 
     val or_constraint =
-      AnyOf(Seq(attr1, attr2, attr3, attr4, attrcnst1, attrcnst2))
+      attr1 || attr2 || attr3 || attr4 || attrcnst1 || attrcnst2
 
     val exceptMSG = intercept[Exception](
       or_constraint.verify(that_attr, constraint_ctx)

--- a/tests/filecheck/clair/test.scala
+++ b/tests/filecheck/clair/test.scala
@@ -3,6 +3,7 @@
 import scair.clair.ir._
 import scair.dialects.builtin.IntData
 import scair.scairdl.constraints._
+import scair.scairdl.constraints.attr2constraint
 
 object Main {
   def main(args: Array[String]) = {
@@ -16,7 +17,7 @@ object Main {
             OperandDef("sing_op1", BaseAttr[IntData]()),
             OperandDef(
               "sing_op2",
-              AnyOf(Seq(EqualAttr(IntData(5)), EqualAttr(IntData(6))))
+              IntData(5) || IntData(6)
             )
           ),
           results = List(
@@ -32,10 +33,10 @@ object Main {
           "VariadicOperandOp",
           operands = List(
             OperandDef("sing_op1", BaseAttr[IntData]()),
-            OperandDef("var_op1", EqualAttr(IntData(5)), Variadicity.Variadic),
+            OperandDef("var_op1", IntData(5), Variadicity.Variadic),
             OperandDef(
               "sing_op2",
-              AnyOf(Seq(EqualAttr(IntData(5)), EqualAttr(IntData(6))))
+              IntData(5) || IntData(6)
             )
           ),
           results = List(
@@ -59,11 +60,11 @@ object Main {
           "MultiVariadicOperandOp",
           operands = List(
             OperandDef("sing_op1", BaseAttr[IntData]()),
-            OperandDef("var_op1", EqualAttr(IntData(5)), Variadicity.Variadic),
-            OperandDef("var_op2", EqualAttr(IntData(5)), Variadicity.Variadic),
+            OperandDef("var_op1", IntData(5), Variadicity.Variadic),
+            OperandDef("var_op2", IntData(5), Variadicity.Variadic),
             OperandDef(
               "sing_op2",
-              AnyOf(Seq(EqualAttr(IntData(5)), EqualAttr(IntData(6))))
+              IntData(5) || IntData(6)
             )
           ),
           results = List(
@@ -94,6 +95,7 @@ object Main {
 // CHECK:       import scair.ir._
 // CHECK-NEXT:  import scair.dialects.builtin._
 // CHECK-NEXT:  import scair.scairdl.constraints._
+// CHECK-NEXT:  import scair.scairdl.constraints.attr2constraint
 
 // CHECK:       object NoVariadicsOp extends DialectOperation {
 // CHECK-NEXT:    override def name = "test.no_variadics"
@@ -136,7 +138,7 @@ object Main {
 // CHECK-NEXT:    def successor2_=(new_successor: Block): Unit = {successors(1) = new_successor}
 
 // CHECK:         val sing_op1_constr = BaseAttr[scair.dialects.builtin.IntData]()
-// CHECK-NEXT:    val sing_op2_constr = AnyOf(List(EqualAttr(IntData(5)), EqualAttr(IntData(6))))
+// CHECK-NEXT:    val sing_op2_constr = IntData(5) || IntData(6)
 // CHECK-NEXT:    val sing_res1_constr = AnyAttr
 // CHECK-NEXT:    val sing_res2_constr = AnyAttr
 
@@ -258,8 +260,8 @@ object Main {
 // CHECK-NEXT:    def successor2_=(new_successor: Block): Unit = {successors(successors.length - 1) = new_successor}
 
 // CHECK:         val sing_op1_constr = BaseAttr[scair.dialects.builtin.IntData]()
-// CHECK-NEXT:    val var_op1_constr = EqualAttr(IntData(5))
-// CHECK-NEXT:    val sing_op2_constr = AnyOf(List(EqualAttr(IntData(5)), EqualAttr(IntData(6))))
+// CHECK-NEXT:    val var_op1_constr = IntData(5)
+// CHECK-NEXT:    val sing_op2_constr = IntData(5) || IntData(6)
 // CHECK-NEXT:    val sing_res1_constr = AnyAttr
 // CHECK-NEXT:    val var_res1_constr = AnyAttr
 // CHECK-NEXT:    val sing_res2_constr = AnyAttr
@@ -305,7 +307,7 @@ object Main {
 // CHECK-NEXT:        case right: DenseArrayAttr => right
 // CHECK-NEXT:        case _ => throw new Exception("Expected operandSegmentSizes to be a DenseArrayAttr")
 // CHECK-NEXT:      }
-// CHECK-NEXT:      ParametrizedAttrConstraint[scair.dialects.builtin.DenseArrayAttr](List(EqualAttr(IntegerType(IntData(32),Signless)), AllOf(List(BaseAttr[scair.dialects.builtin.IntegerAttr](), ParametrizedAttrConstraint[scair.dialects.builtin.IntegerAttr](List(BaseAttr[scair.dialects.builtin.IntData](), EqualAttr(IntegerType(IntData(32),Signless)))))))).verify(operandSegmentSizes_attr, ConstraintContext())
+// CHECK-NEXT:      ParametrizedAttrConstraint[scair.dialects.builtin.DenseArrayAttr](List(IntegerType(IntData(32),Signless), BaseAttr[scair.dialects.builtin.IntegerAttr]() && ParametrizedAttrConstraint[scair.dialects.builtin.IntegerAttr](List(BaseAttr[scair.dialects.builtin.IntData](), IntegerType(IntData(32),Signless))))).verify(operandSegmentSizes_attr, ConstraintContext())
 // CHECK-NEXT:      if (operandSegmentSizes_attr.length != 4) then throw new Exception(s"Expected operandSegmentSizes to have 4 elements, got ${operandSegmentSizes_attr.length}")
 
 // CHECK:           for (s <- operandSegmentSizes_attr) yield s match {
@@ -319,7 +321,7 @@ object Main {
 // CHECK-NEXT:        case right: DenseArrayAttr => right
 // CHECK-NEXT:        case _ => throw new Exception("Expected resultSegmentSizes to be a DenseArrayAttr")
 // CHECK-NEXT:      }
-// CHECK-NEXT:      ParametrizedAttrConstraint[scair.dialects.builtin.DenseArrayAttr](List(EqualAttr(IntegerType(IntData(32),Signless)), AllOf(List(BaseAttr[scair.dialects.builtin.IntegerAttr](), ParametrizedAttrConstraint[scair.dialects.builtin.IntegerAttr](List(BaseAttr[scair.dialects.builtin.IntData](), EqualAttr(IntegerType(IntData(32),Signless)))))))).verify(resultSegmentSizes_attr, ConstraintContext())
+// CHECK-NEXT:      ParametrizedAttrConstraint[scair.dialects.builtin.DenseArrayAttr](List(IntegerType(IntData(32),Signless), BaseAttr[scair.dialects.builtin.IntegerAttr]() && ParametrizedAttrConstraint[scair.dialects.builtin.IntegerAttr](List(BaseAttr[scair.dialects.builtin.IntData](), IntegerType(IntData(32),Signless))))).verify(resultSegmentSizes_attr, ConstraintContext())
 // CHECK-NEXT:      if (resultSegmentSizes_attr.length != 4) then throw new Exception(s"Expected resultSegmentSizes to have 4 elements, got ${resultSegmentSizes_attr.length}")
 
 // CHECK:           for (s <- resultSegmentSizes_attr) yield s match {
@@ -442,9 +444,9 @@ object Main {
 // CHECK-NEXT:    def successor2_=(new_successor: Block): Unit = {successors(successors.length - 1) = new_successor}
 
 // CHECK:         val sing_op1_constr = BaseAttr[scair.dialects.builtin.IntData]()
-// CHECK-NEXT:    val var_op1_constr = EqualAttr(IntData(5))
-// CHECK-NEXT:    val var_op2_constr = EqualAttr(IntData(5))
-// CHECK-NEXT:    val sing_op2_constr = AnyOf(List(EqualAttr(IntData(5)), EqualAttr(IntData(6))))
+// CHECK-NEXT:    val var_op1_constr = IntData(5)
+// CHECK-NEXT:    val var_op2_constr = IntData(5)
+// CHECK-NEXT:    val sing_op2_constr = IntData(5) || IntData(6)
 // CHECK-NEXT:    val sing_res1_constr = AnyAttr
 // CHECK-NEXT:    val var_res1_constr = AnyAttr
 // CHECK-NEXT:    val var_res2_constr = AnyAttr


### PR DESCRIPTION
- Make `constr1 || constr2` parsed to `AnyOf(Seq(constr1, constr2))`, and printed back to.
- Make `constr1 && constr2` parsed to `AllOf(Seq(constr1, constr2))`, and printed back to.
- Flattening constructors for `AnyOf` and `AllOf`, to avoid having weird cascades when using those operators.
- Rely on the existing `Attribute` to `IRDLConstraint` implicit conversion to print `EqualAttr(constr)` just as `constr`
