### PR TITLE
Move transformations out of dialects and allPasses out of core.

### DIFF
--- a/src/main/scala/scair/core/TransformContext.scala
+++ b/src/main/scala/scair/core/TransformContext.scala
@@ -1,15 +1,8 @@
 package scair.transformations
 
-import scair.dialects.CMath.transformations.cdt.{
-  DummyPass,
-  TestInsertionPass,
-  TestReplacementPass
-}
 import scala.collection.mutable
 import scair._
-
-private val allPasses: Seq[ModulePass] =
-  Seq(DummyPass, TestInsertionPass, TestReplacementPass)
+import scair.utils.allPasses
 
 class TransformContext() {
 

--- a/src/main/scala/scair/tools/utils.scala
+++ b/src/main/scala/scair/tools/utils.scala
@@ -1,6 +1,6 @@
 package scair.utils
 
-import scair.ir._
+import scair.ir.Dialect
 import scair.dialects.CMath.cmath.CMath
 import scair.dialects.LingoDB.TupleStream.TupleStreamDialect
 import scair.dialects.LingoDB.DBOps.DBOps
@@ -10,3 +10,13 @@ import scair.dialects.affine.Affine
 
 val allDialects: Seq[Dialect] =
   Seq(CMath, TupleStreamDialect, DBOps, SubOperatorOps, RelAlgOps, Affine)
+
+import scair.transformations.ModulePass
+import scair.transformations.cdt.{
+  DummyPass,
+  TestInsertionPass,
+  TestReplacementPass
+}
+
+val allPasses: Seq[ModulePass] =
+  Seq(DummyPass, TestInsertionPass, TestReplacementPass)

--- a/src/main/scala/scair/transformations/cmath-dummy-transform.scala
+++ b/src/main/scala/scair/transformations/cmath-dummy-transform.scala
@@ -1,4 +1,4 @@
-package scair.dialects.CMath.transformations.cdt
+package scair.transformations.cdt
 
 import scair.ir._
 import scair.dialects.builtin.StringData


### PR DESCRIPTION
cf:
- #112 

- Move transformations out of dialects, so that their compilation can be nicely ordered.
- Move allPasses out of core, so that core does not depend on all transformations, to follow allDialect's design. (This was technically not as necessary here, but if we want to generate transformations at some point...)