### PR TITLE
Provide an `install` sbt task to install Scair to $HOME/.local.

### DIFF
--- a/built.sbt
+++ b/built.sbt
@@ -3,7 +3,7 @@ import sbt.util.FileInfo.full
 import scala.sys.process._
 import java.io.{File}
 import java.nio.file.{Files, Path, StandardCopyOption}
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 
 ThisBuild / scalaVersion := "3.3.4"
@@ -128,7 +128,7 @@ def copyDir(source: Path, target: Path) : Unit = {
       Files.createDirectories(target);
   }
   val stream = Files.newDirectoryStream(source)
-  for (entry <- stream) {
+  for (entry <- stream.asScala) {
       val newTarget = target.resolve(source.relativize(entry));
       if (Files.isDirectory(entry)) {
           copyDir(entry, newTarget);

--- a/built.sbt
+++ b/built.sbt
@@ -62,7 +62,9 @@ lazy val tools =
     .dependsOn(gen_dialects, transformations)
     .enablePlugins(JavaAppPackaging)
     .settings(
-      name := "scair"
+      name := "scair",
+      // Skip the docs when simply packaging CLI tools
+      Compile / packageDoc / mappings := Seq(), 
     )
 
 ///////////////////////////
@@ -94,7 +96,7 @@ lazy val filechecks = taskKey[Unit]("File checks")
 filechecks := {
   // It expects this task to populate a helper file
   (filechecks_classpath).value
-  // It depends on scair-opt, built by the "stage" task currently
+  // It depends on scair CLI, built by the "stage" task currently
   (tools / stage).value
   // And then it's about running lit
   val r = ("lit tests/filecheck -v" !)

--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -6,7 +6,7 @@ config.test_source_root = os.path.dirname(__file__)
 config.test_format = lit.formats.ShTest(preamble_commands=[f"cd {config.test_source_root}"])
 config.suffixes = ['.mlir', '.scala']
 
-scair_opt = os.path.abspath(os.path.join(config.test_source_root, '../../tools/target/universal/stage/bin/tools'))
+scair_opt = os.path.abspath(os.path.join(config.test_source_root, '../../tools/target/universal/stage/bin/scair'))
 config.substitutions.append(('scair-opt', f"{scair_opt}"))
 
 full_classpath = open(os.path.abspath('full-classpath')).read()

--- a/tools/src/main/scala-3/ScairOpt.scala
+++ b/tools/src/main/scala-3/ScairOpt.scala
@@ -1,3 +1,5 @@
+package scair.tools
+
 import scair.MLContext
 import scair.Printer
 import scair.TransformContext

--- a/tools/src/main/scala-3/ScairOpt.scala
+++ b/tools/src/main/scala-3/ScairOpt.scala
@@ -24,8 +24,8 @@ object ScairOpt {
     val argparser = {
       import argbuilder._
       OParser.sequence(
-        programName("scair-opt"),
-        head("scair-opt", "0"),
+        programName("scair"),
+        head("scair", "0"),
         // The input file - defaulting to stdin
         arg[String]("file")
           .optional()


### PR DESCRIPTION
A first step in the direction of providing clean installation logic to just use scair from the CLI normally on one's system