### PR TITLE
Recreating the whitespace issue

### DIFF
--- a/core/src/main/scala-3/Parser.scala
+++ b/core/src/main/scala-3/Parser.scala
@@ -877,7 +877,6 @@ class Parser(val context: MLContext, val args: Args = Args())
     PrettyDialectReferenceName.flatMap { (x: String, y: String) =>
       ctx.getOperation(s"${x}.${y}") match {
         case Some(y) =>
-          println(y)
           y.parse(resNames, this)
         case None =>
           throw new Exception(

--- a/core/src/main/scala-3/Parser.scala
+++ b/core/src/main/scala-3/Parser.scala
@@ -877,6 +877,7 @@ class Parser(val context: MLContext, val args: Args = Args())
     PrettyDialectReferenceName.flatMap { (x: String, y: String) =>
       ctx.getOperation(s"${x}.${y}") match {
         case Some(y) =>
+          println(y)
           y.parse(resNames, this)
         case None =>
           throw new Exception(

--- a/core/src/main/scala-3/scairdl/IRElements.scala
+++ b/core/src/main/scala-3/scairdl/IRElements.scala
@@ -4,7 +4,7 @@ import scair.dialects.builtin.*
 import scair.ir.Attribute
 import scair.ir.Operation
 import scair.scairdl.constraints.*
-
+import scair.Printer
 import java.io.File
 import java.io.PrintStream
 import scala.collection.mutable
@@ -128,9 +128,14 @@ case class DialectDef(
     s"""package scair.dialects.${name.toLowerCase}
 
 import scair.ir._
+import scair.Parser
+import scair.Parser.whitespace
+
 import scair.dialects.builtin._
 import scair.scairdl.constraints._
-import scair.scairdl.constraints.attr2constraint"""
+import scair.scairdl.constraints.attr2constraint
+import fastparse.ScalaWhitespace.whitespace
+import fastparse.*"""
       + { for (hatch <- opHatches) yield hatch.importt }
         .mkString("\n", "\n", "\n") +
       { for (hatch <- attrHatches) yield hatch.importt }
@@ -147,9 +152,30 @@ val ${name}Dialect: Dialect = new Dialect(
 
 }
 
+case class Assemblyformat(
+    format: String,
+    operands: Seq[String], //  ["$lhs", "$rhs"]
+    types: Seq[String],    //  ["type($lhs)", "type($rhs)"]
+    results: Seq[String]   //  ["type($result)"]
+)
+
 /*≡≡=---=≡≡≡≡≡=---=≡≡*\
 ||   OPERATION DEF   ||
 \*≡==----=≡≡≡=----==≡*/
+
+// class FormatDirective
+// // `literal`
+// class LiteralDirective extends FormatDirective
+
+// // $name if name is an operand of the Op
+// class OperandDirective(name : String)
+// // $name if name is a result of the Op
+// class ResultDirective(name: String)
+
+// // type($name)
+// class TypeDirective(dir : FormatDirective)
+
+// Seq[FormatDirective]
 
 case class OperationDef(
     val name: String,
@@ -162,6 +188,108 @@ case class OperationDef(
     val OpAttribute: Seq[OpAttributeDef] = Seq(),
     val assembly_format: Option[String] = None
 ) {
+  //considering fastmath later... what if operand 2 comes earlier... it's too much hardcoded 
+
+  def Parseassemblyformat(format: String): Assemblyformat = {
+    val Operandpattern = """\$(\w+)(?=(\s|`|,|$))""".r 
+    // val Operandpattern = """\$(\w+)(?!\))""".r
+    val Typepattern = """type\(\$(\w+)\)""".r //type($lhs), type($rhs)
+    // val flag = 
+    val Operands = Operandpattern.findAllMatchIn(format).map(_.group(1)).toSeq
+    val Types = Typepattern.findAllMatchIn(format).map(_.group(1)).toSeq //types = Seq("lhs", "rhs")
+    val result = if (format.contains("type($result)")) Seq("result") else Seq() //not sure
+    val ResultPattern = """type\(\$result\)""".r 
+    val results = ResultPattern.findAllMatchIn(format).flatMap { m =>
+  if (m.groupCount >= 1) Some(m.group(1)) else None
+}.toSeq
+    val filteredOperands = Operands.filterNot(_ == "result")
+    val filteredTypes = Types.filterNot(_ == "result")
+    Assemblyformat(format, filteredOperands, filteredTypes, result)
+}
+
+
+
+def Generateparsefunction(format: Assemblyformat): String = {
+  println(f"$name : $format")
+  val operandVars = format.operands.zipWithIndex.map { case (name, idx) => s"${name}_$idx" }
+  val typeVars = format.types.zipWithIndex.map { case (name, idx) => s"type_${name}_$idx" }
+  val resultVars = format.results.zipWithIndex.map { case (name, idx) => s"type_${name}_$idx" }
+
+  val patternVariables = (operandVars ++ typeVars ++ resultVars).mkString(", ")
+
+  val operandParsing = if (format.operands.nonEmpty) {
+    format.operands.map(_ => "Parser.ValueUse").mkString(" ~ ")
+  } else {
+    "\"\"" 
+  }
+
+  val typeParsing = if (format.types.nonEmpty) {
+    format.types.map(_ => "parser.Type").mkString(" ~ ")
+  } else {
+    "\"\"" 
+  }
+  val resultParsing = if (format.results.nonEmpty) {
+    format.results.map(_ => "parser.Type").mkString(" ~ ")
+  } else {
+    "\"\"" 
+  }
+
+  val combinedParsing = Seq(operandParsing, typeParsing, resultParsing)
+    .filterNot(_ == "\"\"") 
+    .mkString(" ~ ")
+
+  val finalParsing = if (combinedParsing.isEmpty) "\"\"" else combinedParsing
+
+  f"""
+  override def parse[$$: P](
+      resNames: Seq[String],
+      parser: Parser
+  ): P[Operation] = {
+      P(
+        $finalParsing
+      ).map {
+          ${if (patternVariables.nonEmpty) s"($patternVariables)" else "()"} =>
+          println("Parsing $name")
+          parser.verifyCustomOp(
+            opGen = $className.factory,
+            opName = name,
+            operandNames = Seq(${operandVars.mkString(", ")}),
+            operandTypes = Seq(${typeVars.mkString(", ")}),
+            resultNames = resNames,
+            resultTypes = Seq(${resultVars.mkString(", ")})
+          )
+      }
+  }
+  """
+}
+
+  def GeneratePrintFunction(printer: Printer): String = {
+  val operandPrinting = operands.zipWithIndex.map { case (name, idx) =>
+    s"""val operand_$idx = s"$${printer.printValue(operands($idx).asInstanceOf[Value[Attribute]])} : $${operands($idx).typ.custom_print}""""
+  }.mkString("\n    ")
+
+  val resultPrinting = if (results.nonEmpty) {
+    s"""val resultType = results.head.typ.custom_print"""
+  } else {
+    ""
+  }
+
+  val operandSequence = operands.indices.map(idx => s"operand_$idx").mkString(", ")
+
+  val finalPrintStatement =
+    if (results.nonEmpty) s"""s"$$name $$operandSequence : $$resultType" """
+    else s"""s"$$name $$operandSequence" """
+
+  f"""
+  override def custom_print(printer: Printer): String = {
+    $operandPrinting
+    $resultPrinting
+    $finalPrintStatement
+  }
+  """
+}
+
+
 
   def operand_segment_sizes_helper: String =
     s"""def operandSegmentSizes: Seq[Int] =
@@ -642,7 +770,7 @@ case class OperationDef(
 object $className extends OperationObject {
   override def name = "$name"
   override def factory = $className.apply
-  ${assembly_format.map(f => f"val replace_by_parse = \"$f\"").getOrElse("")}
+  ${assembly_format.map(f => Generateparsefunction(Parseassemblyformat(f))).getOrElse("")}
 }
 
 case class $className(
@@ -656,7 +784,7 @@ case class $className(
       DictType.empty[String, Attribute]
 ) extends RegisteredOperation(name = "$name") {
 
-${assembly_format.map(f => f"val replace_by_print = \"$f\"").getOrElse("")}
+// ${assembly_format.map(f => f"val replace_by_print = \"$f\"").getOrElse("")}
 
 ${helpers(indent + 1)}
 ${accessors(indent + 1)}

--- a/dialects/src/main/scala-3/affine/Affine.scala
+++ b/dialects/src/main/scala-3/affine/Affine.scala
@@ -41,8 +41,7 @@ case class For(
     lowerBoundMap: Property[AffineMapAttr],
     upperBoundMap: Property[AffineMapAttr],
     step: Property[IntegerAttr],
-    body: Region,
-    assembly_format: "daiowdjwiojd"
+    body: Region
 ) extends OperationFE
 
 /*≡==---==≡≡≡≡≡==---=≡≡*\

--- a/dialects/src/main/scala-3/arith/Arith.scala
+++ b/dialects/src/main/scala-3/arith/Arith.scala
@@ -127,95 +127,113 @@ type IntegerPredicate = IntegerAttr
 case class Addf(
     lhs: Operand[FloatType],
     rhs: Operand[FloatType],
-    res: Result[FloatType],
-    fastmath: Property[FastMathFlagsAttr]
+    result: Result[FloatType],
+    fastmath: Property[FastMathFlagsAttr],
+    assembly_format : "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
 ) extends OperationFE
 
 case class Mulf(
     lhs: Operand[FloatType],
     rhs: Operand[FloatType],
-    res: Result[FloatType],
-    fastmath: Property[FastMathFlagsAttr]
-) extends OperationFE
+    result: Result[FloatType],
+    fastmath: Property[FastMathFlagsAttr],
+    assembly_format : "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
 
+) extends OperationFE
+// I'm not sure about the flag here
 case class Divf(
     lhs: Operand[FloatType],
     rhs: Operand[FloatType],
-    res: Result[FloatType],
-    fastmath: Property[FastMathFlagsAttr]
+    result: Result[FloatType],
+    fastmath: Property[FastMathFlagsAttr],
+    assembly_format : "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
 ) extends OperationFE
 
 // TODO Apparently there's a new overflow flag here, overlooking for now.
 case class Addi(
     lhs: Operand[AnyIntegerType],
     rhs: Operand[AnyIntegerType],
-    res: Result[AnyIntegerType]
+    result: Result[AnyIntegerType],
+    assembly_format : "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
 ) extends OperationFE
 
 case class Subi(
     lhs: Operand[AnyIntegerType],
     rhs: Operand[AnyIntegerType],
-    res: Result[AnyIntegerType]
+    result: Result[AnyIntegerType],
+    assembly_format : "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
 ) extends OperationFE
 
 case class Muli(
     lhs: Operand[AnyIntegerType],
     rhs: Operand[AnyIntegerType],
-    res: Result[AnyIntegerType]
+    result: Result[AnyIntegerType],    
+    assembly_format : "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
 ) extends OperationFE
 
 case class Divui(
     lhs: Operand[AnyIntegerType],
     rhs: Operand[AnyIntegerType],
-    res: Result[AnyIntegerType]
+    result: Result[AnyIntegerType],
+    assembly_format : "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
 ) extends OperationFE
 
 case class Divsi(
     lhs: Operand[AnyIntegerType],
     rhs: Operand[AnyIntegerType],
-    res: Result[AnyIntegerType]
+    result: Result[AnyIntegerType],
+    assembly_format : "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
 ) extends OperationFE
 
 case class Remui(
     lhs: Operand[AnyIntegerType],
     rhs: Operand[AnyIntegerType],
-    res: Result[AnyIntegerType]
+    result: Result[AnyIntegerType],
+    assembly_format : "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
 ) extends OperationFE
 
 case class Remsi(
     lhs: Operand[AnyIntegerType],
     rhs: Operand[AnyIntegerType],
-    res: Result[AnyIntegerType]
+    result: Result[AnyIntegerType],
+    assembly_format : "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
 ) extends OperationFE
 
 case class Cmpi(
     lhs: Operand[AnyIntegerType],
     rhs: Operand[AnyIntegerType],
-    res: Result[I1],
-    predicate: Property[IntegerPredicate]
+    result: Result[I1],
+    predicate: Property[IntegerPredicate],
+    assembly_format : "$predicate `,` $lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
 ) extends OperationFE
 
 case class Andi(
     lhs: Operand[AnyIntegerType],
     rhs: Operand[AnyIntegerType],
-    res: Result[I1]
+    result: Result[I1],
+    assembly_format : "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
 ) extends OperationFE
 
 case class Ori(
     lhs: Operand[AnyIntegerType],
     rhs: Operand[AnyIntegerType],
-    res: Result[I1]
+    result: Result[I1],
+    assembly_format : "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
 ) extends OperationFE
+
 
 case class Sitofp(
     in: Operand[AnyIntegerType],
-    res: Result[FloatType]
+    out: Result[FloatType],
+    assembly_format : "$in `:` type($in) `to` type($out)"
 ) extends OperationFE
 
 case class Index_Cast(
     in: Operand[AnyIntegerType],
-    res: Result[AnyIntegerType]
+    result: Result[AnyIntegerType],
+    assembly_format : "$in `:` type($in) `to` type($out)"
 ) extends OperationFE
+
 
 object ArithGen
     extends ScaIRDLDialect(

--- a/tests/filecheck/core/general/.scala-build/ide-inputs.json
+++ b/tests/filecheck/core/general/.scala-build/ide-inputs.json
@@ -1,1 +1,1 @@
-{"args":["/home/maks/phd/scair/scair/tests/filecheck/core/general/hello_world.scala"]}
+{"args":["/home/maks/phd/scair/pardis-parsing/scair/tests/filecheck/core/general/hello_world.scala"]}

--- a/tests/filecheck/dialects/arith/arith_ops.mlir
+++ b/tests/filecheck/dialects/arith/arith_ops.mlir
@@ -1,48 +1,49 @@
-// RUN: scair-opt %s | filecheck %s
+// // RUN: scair-opt %s | filecheck %s
 
-%lhsi1, %rhsi1 = "test.op"() : () -> (i1, i1)
-%lhsi32, %rhsi32 = "test.op"() : () -> (i32, i32)
-%lhsi64, %rhsi64 = "test.op"() : () -> (i64, i64)
-%lhsindex, %rhsindex = "test.op"() : () -> (index, index)
-%lhsf32, %rhsf32 = "test.op"() : () -> (f32, f32)
-%lhsf64, %rhsf64 = "test.op"() : () -> (f64, f64)
+// %lhsi1, %rhsi1 = "test.op"() : () -> (i1, i1)
+%lhsi32, %rhsi32, %pred32 = "test.op"() : () -> (i32, i32, i32)
+// %lhsi64, %rhsi64 = "test.op"() : () -> (i64, i64)
+// %lhsindex, %rhsindex = "test.op"() : () -> (index, index)
+// %lhsf32, %rhsf32 = "test.op"() : () -> (f32, f32)
+// %lhsf64, %rhsf64 = "test.op"() : () -> (f64, f64)
 
-%divsi = "arith.divsi"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-// CHECK:         %12 = "arith.divsi"(%2, %3) : (i32, i32) -> (i32)
-%divsi_index = "arith.divsi"(%lhsindex, %rhsindex) : (index, index) -> index
-// CHECK-NEXT:    %13 = "arith.divsi"(%6, %7) : (index, index) -> (index)
-%divui = "arith.divui"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-// CHECK-NEXT:    %14 = "arith.divui"(%2, %3) : (i32, i32) -> (i32)
-%divui_index = "arith.divui"(%lhsindex, %rhsindex) : (index, index) -> index
-// CHECK-NEXT:    %15 = "arith.divui"(%6, %7) : (index, index) -> (index)
-%remsi = "arith.remsi"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-// CHECK-NEXT:    %16 = "arith.remsi"(%2, %3) : (i32, i32) -> (i32)
-%remui = "arith.remui"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-// CHECK-NEXT:    %17 = "arith.remui"(%2, %3) : (i32, i32) -> (i32)
-%remui_index = "arith.remui"(%lhsindex, %rhsindex) : (index, index) -> index
-// CHECK-NEXT:    %18 = "arith.remui"(%6, %7) : (index, index) -> (index)
-%cmpi = "arith.cmpi"(%lhsi32, %rhsi32) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:    %19 = "arith.cmpi"(%2, %3) <{predicate = 2}> : (i32, i32) -> (i1)
-%cmpi_index = "arith.cmpi"(%lhsindex, %rhsindex) <{"predicate" = 2 : i64}> : (index, index) -> i1
-// CHECK-NEXT:    %20 = "arith.cmpi"(%6, %7) <{predicate = 2}> : (index, index) -> (i1)
-%addi = "arith.addi"(%lhsi32, %rhsi32) {"hello" = "world"} : (i32, i32) -> i32
-// CHECK-NEXT:    %21 = "arith.addi"(%2, %3) {hello = "world"} : (i32, i32) -> (i32)
-%addf = "arith.addf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<none>}> : (f32, f32) -> f32
-// CHECK-NEXT:    %22 = "arith.addf"(%8, %9) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> (f32)
+// %divsi = "arith.divsi"(%lhsi32, %rhsi32) : (i32, i32) -> i32
+// // CHECK:         %12 = "arith.divsi"(%2, %3) : (i32, i32) -> (i32)
+// %divsi_index = "arith.divsi"(%lhsindex, %rhsindex) : (index, index) -> index
+// // CHECK-NEXT:    %13 = "arith.divsi"(%6, %7) : (index, index) -> (index)
+// %divui = "arith.divui"(%lhsi32, %rhsi32) : (i32, i32) -> i32
+// // CHECK-NEXT:    %14 = "arith.divui"(%2, %3) : (i32, i32) -> (i32)
+// %divui_index = "arith.divui"(%lhsindex, %rhsindex) : (index, index) -> index
+// // CHECK-NEXT:    %15 = "arith.divui"(%6, %7) : (index, index) -> (index)
+// %remsi = "arith.remsi"(%lhsi32, %rhsi32) : (i32, i32) -> i32
+%remsi2 = arith.remsi %lhsi32 %rhsi32 i32 i32
+// // CHECK-NEXT:    %16 = "arith.remsi"(%2, %3) : (i32, i32) -> (i32)
+// %remui = "arith.remui"(%lhsi32, %rhsi32) : (i32, i32) -> i32
+// // CHECK-NEXT:    %17 = "arith.remui"(%2, %3) : (i32, i32) -> (i32)
+// %remui_index = "arith.remui"(%lhsindex, %rhsindex) : (index, index) -> index
+// // CHECK-NEXT:    %18 = "arith.remui"(%6, %7) : (index, index) -> (index)
+// %cmpi = "arith.cmpi"(%lhsi32, %rhsi32) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
+// // CHECK-NEXT:    %19 = "arith.cmpi"(%2, %3) <{predicate = 2}> : (i32, i32) -> (i1)
+// %cmpi_index = "arith.cmpi"(%lhsindex, %rhsindex) <{"predicate" = 2 : i64}> : (index, index) -> i1
+// // CHECK-NEXT:    %20 = "arith.cmpi"(%6, %7) <{predicate = 2}> : (index, index) -> (i1)
+// %addi = "arith.addi"(%lhsi32, %rhsi32) {"hello" = "world"} : (i32, i32) -> i32
+// // CHECK-NEXT:    %21 = "arith.addi"(%2, %3) {hello = "world"} : (i32, i32) -> (i32)
+// %addf = "arith.addf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<none>}> : (f32, f32) -> f32
+// // CHECK-NEXT:    %22 = "arith.addf"(%8, %9) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> (f32)
 
-%addf_vector = "arith.addf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<none>}> : (f32, f32) -> f32
-// CHECK-NEXT:    %23 = "arith.addf"(%8, %9) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> (f32)
-%mulf = "arith.mulf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<none>}> : (f32, f32) -> f32
-// CHECK-NEXT:    %24 = "arith.mulf"(%8, %9) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> (f32)
-%mulf_vector = "arith.mulf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<none>}> : (f32, f32) -> f32
-// CHECK-NEXT:    %25 = "arith.mulf"(%8, %9) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> (f32)
-%divf = "arith.divf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<none>}> : (f32, f32) -> f32
-// CHECK-NEXT:    %26 = "arith.divf"(%8, %9) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> (f32)
-%divf_vector = "arith.divf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<none>}> : (f32, f32) -> f32
-// CHECK-NEXT:    %27 = "arith.divf"(%8, %9) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> (f32)
-%faddf = "arith.addf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<fast>}> : (f32, f32) -> f32
-// CHECK-NEXT:    %28 = "arith.addf"(%8, %9) <{fastmath = #arith.fastmath<fast>}> : (f32, f32) -> (f32)
-%faddf_vector = "arith.addf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<fast>}> : (f32, f32) -> f32
-// CHECK-NEXT:    %29 = "arith.addf"(%8, %9) <{fastmath = #arith.fastmath<fast>}> : (f32, f32) -> (f32)
-%index = "arith.index_cast"(%lhsi32) : (i32) -> index
-// CHECK-NEXT:    %30 = "arith.index_cast"(%2) : (i32) -> (index)
+// %addf_vector = "arith.addf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<none>}> : (f32, f32) -> f32
+// // CHECK-NEXT:    %23 = "arith.addf"(%8, %9) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> (f32)
+// %mulf = "arith.mulf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<none>}> : (f32, f32) -> f32
+// // CHECK-NEXT:    %24 = "arith.mulf"(%8, %9) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> (f32)
+// %mulf_vector = "arith.mulf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<none>}> : (f32, f32) -> f32
+// // CHECK-NEXT:    %25 = "arith.mulf"(%8, %9) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> (f32)
+// %divf = "arith.divf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<none>}> : (f32, f32) -> f32
+// // CHECK-NEXT:    %26 = "arith.divf"(%8, %9) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> (f32)
+// %divf_vector = "arith.divf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<none>}> : (f32, f32) -> f32
+// // CHECK-NEXT:    %27 = "arith.divf"(%8, %9) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> (f32)
+// %faddf = "arith.addf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<fast>}> : (f32, f32) -> f32
+// // CHECK-NEXT:    %28 = "arith.addf"(%8, %9) <{fastmath = #arith.fastmath<fast>}> : (f32, f32) -> (f32)
+// %faddf_vector = "arith.addf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<fast>}> : (f32, f32) -> f32
+// // CHECK-NEXT:    %29 = "arith.addf"(%8, %9) <{fastmath = #arith.fastmath<fast>}> : (f32, f32) -> (f32)
+// %index = "arith.index_cast"(%lhsi32) : (i32) -> index
+// // CHECK-NEXT:    %30 = "arith.index_cast"(%2) : (i32) -> (index)

--- a/tests/filecheck/dialects/arith/arith_ops.mlir
+++ b/tests/filecheck/dialects/arith/arith_ops.mlir
@@ -1,49 +1,7 @@
-// // RUN: scair-opt %s | filecheck %s
+// RUN: scair-opt %s 
 
-// %lhsi1, %rhsi1 = "test.op"() : () -> (i1, i1)
 %lhsi32, %rhsi32, %pred32 = "test.op"() : () -> (i32, i32, i32)
-// %lhsi64, %rhsi64 = "test.op"() : () -> (i64, i64)
-// %lhsindex, %rhsindex = "test.op"() : () -> (index, index)
-// %lhsf32, %rhsf32 = "test.op"() : () -> (f32, f32)
-// %lhsf64, %rhsf64 = "test.op"() : () -> (f64, f64)
 
-// %divsi = "arith.divsi"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-// // CHECK:         %12 = "arith.divsi"(%2, %3) : (i32, i32) -> (i32)
-// %divsi_index = "arith.divsi"(%lhsindex, %rhsindex) : (index, index) -> index
-// // CHECK-NEXT:    %13 = "arith.divsi"(%6, %7) : (index, index) -> (index)
-// %divui = "arith.divui"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-// // CHECK-NEXT:    %14 = "arith.divui"(%2, %3) : (i32, i32) -> (i32)
-// %divui_index = "arith.divui"(%lhsindex, %rhsindex) : (index, index) -> index
-// // CHECK-NEXT:    %15 = "arith.divui"(%6, %7) : (index, index) -> (index)
-// %remsi = "arith.remsi"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-%remsi2 = arith.remsi %lhsi32 %rhsi32 i32 i32
-// // CHECK-NEXT:    %16 = "arith.remsi"(%2, %3) : (i32, i32) -> (i32)
-// %remui = "arith.remui"(%lhsi32, %rhsi32) : (i32, i32) -> i32
-// // CHECK-NEXT:    %17 = "arith.remui"(%2, %3) : (i32, i32) -> (i32)
-// %remui_index = "arith.remui"(%lhsindex, %rhsindex) : (index, index) -> index
-// // CHECK-NEXT:    %18 = "arith.remui"(%6, %7) : (index, index) -> (index)
-// %cmpi = "arith.cmpi"(%lhsi32, %rhsi32) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
-// // CHECK-NEXT:    %19 = "arith.cmpi"(%2, %3) <{predicate = 2}> : (i32, i32) -> (i1)
-// %cmpi_index = "arith.cmpi"(%lhsindex, %rhsindex) <{"predicate" = 2 : i64}> : (index, index) -> i1
-// // CHECK-NEXT:    %20 = "arith.cmpi"(%6, %7) <{predicate = 2}> : (index, index) -> (i1)
-// %addi = "arith.addi"(%lhsi32, %rhsi32) {"hello" = "world"} : (i32, i32) -> i32
-// // CHECK-NEXT:    %21 = "arith.addi"(%2, %3) {hello = "world"} : (i32, i32) -> (i32)
-// %addf = "arith.addf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<none>}> : (f32, f32) -> f32
-// // CHECK-NEXT:    %22 = "arith.addf"(%8, %9) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> (f32)
 
-// %addf_vector = "arith.addf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<none>}> : (f32, f32) -> f32
-// // CHECK-NEXT:    %23 = "arith.addf"(%8, %9) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> (f32)
-// %mulf = "arith.mulf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<none>}> : (f32, f32) -> f32
-// // CHECK-NEXT:    %24 = "arith.mulf"(%8, %9) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> (f32)
-// %mulf_vector = "arith.mulf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<none>}> : (f32, f32) -> f32
-// // CHECK-NEXT:    %25 = "arith.mulf"(%8, %9) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> (f32)
-// %divf = "arith.divf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<none>}> : (f32, f32) -> f32
-// // CHECK-NEXT:    %26 = "arith.divf"(%8, %9) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> (f32)
-// %divf_vector = "arith.divf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<none>}> : (f32, f32) -> f32
-// // CHECK-NEXT:    %27 = "arith.divf"(%8, %9) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> (f32)
-// %faddf = "arith.addf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<fast>}> : (f32, f32) -> f32
-// // CHECK-NEXT:    %28 = "arith.addf"(%8, %9) <{fastmath = #arith.fastmath<fast>}> : (f32, f32) -> (f32)
-// %faddf_vector = "arith.addf"(%lhsf32, %rhsf32) <{"fastmath" = #arith.fastmath<fast>}> : (f32, f32) -> f32
-// // CHECK-NEXT:    %29 = "arith.addf"(%8, %9) <{fastmath = #arith.fastmath<fast>}> : (f32, f32) -> (f32)
-// %index = "arith.index_cast"(%lhsi32) : (i32) -> index
-// // CHECK-NEXT:    %30 = "arith.index_cast"(%2) : (i32) -> (index)
+%remsi2 = arith.remsi %lhsi32 %rhsi32 i32 i32 i32
+// CHECK-NEXT:    %16 = "arith.remsi"(%2, %3) : (i32, i32) -> (i32)


### PR DESCRIPTION
- stage the sbt
- run the "lit -v tests/filecheck/dialects/arith/arith_ops.mlir"

- there are currently 3 different parts to the generators
   - operandsParsing =>  will be printed
   - typeParsing          =>  will not be printed
   - resultParsing       =>  will not be printed

- each unique successful parsing of a value or type will be shown as a '.', parsed values will be additionally shown
- there is a separating line "switch", that lets you know where you are in the 3 different parsers