### PR TITLE
Early Parser refactor

### DIFF
--- a/dialects/src/main/scala-3/lingodb/DBOps.scala
+++ b/dialects/src/main/scala-3/lingodb/DBOps.scala
@@ -279,12 +279,11 @@ object DB_ConstantOp extends OperationObject {
         y: Attribute,
         z: Seq[(String, Attribute)]
     ) =>
-      parser.verifyCustomOp(
-        opGen = factory,
+      parser.generateOperation(
         opName = name,
-        resultNames = resNames,
-        resultTypes = Seq(y),
-        dictAttrs = z :+ ("value", x)
+        resultsNames = resNames,
+        resultsTypes = Seq(y),
+        attributes = z :+ ("value", x)
       )
   )
   // ==----------------------== //
@@ -355,14 +354,13 @@ object DB_CmpOp extends OperationObject {
         rightType: Attribute,
         z: Seq[(String, Attribute)]
     ) =>
-      parser.verifyCustomOp(
-        opGen = factory,
+      parser.generateOperation(
         opName = name,
-        resultNames = resNames,
-        resultTypes = Seq(I1),
-        operandNames = Seq(left, right),
-        operandTypes = Seq(leftType, rightType),
-        dictAttrs = z :+ ("predicate", x)
+        resultsNames = resNames,
+        resultsTypes = Seq(I1),
+        operandsNames = Seq(left, right),
+        operandsTypes = Seq(leftType, rightType),
+        attributes = z :+ ("predicate", x)
       )
   )
   // ==----------------------== //
@@ -500,14 +498,13 @@ object DB_MulOp extends OperationObject {
         rightType: Attribute,
         z: Seq[(String, Attribute)]
     ) =>
-      parser.verifyCustomOp(
-        opGen = factory,
+      parser.generateOperation(
         opName = name,
-        resultNames = resNames,
-        resultTypes = inferRetType(leftType, rightType),
-        operandNames = Seq(left, right),
-        operandTypes = Seq(leftType, rightType),
-        dictAttrs = z
+        resultsNames = resNames,
+        resultsTypes = inferRetType(leftType, rightType),
+        operandsNames = Seq(left, right),
+        operandsTypes = Seq(leftType, rightType),
+        attributes = z
       )
   )
   // ==----------------------== //
@@ -650,14 +647,13 @@ object DB_DivOp extends OperationObject {
         rightType: Attribute,
         z: Seq[(String, Attribute)]
     ) =>
-      parser.verifyCustomOp(
-        opGen = factory,
+      parser.generateOperation(
         opName = name,
-        operandNames = Seq(left, right),
-        operandTypes = Seq(leftType, rightType),
-        resultNames = resNames,
-        resultTypes = inferRetType(leftType, rightType),
-        dictAttrs = z
+        operandsNames = Seq(left, right),
+        operandsTypes = Seq(leftType, rightType),
+        resultsNames = resNames,
+        resultsTypes = inferRetType(leftType, rightType),
+        attributes = z
       )
   )
   // ==----------------------== //
@@ -736,14 +732,13 @@ object DB_AddOp extends OperationObject {
         rightType: Attribute,
         z: Seq[(String, Attribute)]
     ) =>
-      parser.verifyCustomOp(
-        opGen = factory,
+      parser.generateOperation(
         opName = name,
-        resultNames = resNames,
-        resultTypes = Seq(leftType),
-        operandNames = Seq(left, right),
-        operandTypes = Seq(leftType, rightType),
-        dictAttrs = z
+        resultsNames = resNames,
+        resultsTypes = Seq(leftType),
+        operandsNames = Seq(left, right),
+        operandsTypes = Seq(leftType, rightType),
+        attributes = z
       )
   )
   // ==----------------------== //
@@ -824,14 +819,13 @@ object DB_SubOp extends OperationObject {
         rightType: Attribute,
         z: Seq[(String, Attribute)]
     ) =>
-      parser.verifyCustomOp(
-        opGen = factory,
+      parser.generateOperation(
         opName = name,
-        resultNames = resNames,
-        resultTypes = Seq(leftType),
-        operandNames = Seq(left, right),
-        operandTypes = Seq(leftType, rightType),
-        dictAttrs = z
+        resultsNames = resNames,
+        resultsTypes = Seq(leftType),
+        operandsNames = Seq(left, right),
+        operandsTypes = Seq(leftType, rightType),
+        attributes = z
       )
   )
   // ==----------------------== //
@@ -909,14 +903,13 @@ object CastOp extends OperationObject {
         resTypes: Seq[Attribute],
         z: Seq[(String, Attribute)]
     ) =>
-      parser.verifyCustomOp(
-        opGen = factory,
+      parser.generateOperation(
         opName = name,
-        resultNames = resNames,
-        resultTypes = resTypes,
-        operandNames = Seq(operand),
-        operandTypes = Seq(opType),
-        dictAttrs = z
+        resultsNames = resNames,
+        resultsTypes = resTypes,
+        operandsNames = Seq(operand),
+        operandsTypes = Seq(opType),
+        attributes = z
       )
   )
   // ==----------------------== //

--- a/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
+++ b/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
@@ -7,7 +7,6 @@ import scair.EnumAttr.I64EnumAttrCase
 import scair.Parser
 import scair.Parser.BareId
 import scair.Parser.E
-import scair.Parser.Scope
 import scair.Parser.ValueId
 import scair.Parser.optionlessSeq
 import scair.Parser.whitespace
@@ -173,13 +172,12 @@ object BaseTableOp extends OperationObject {
         x: Seq[(String, Attribute)],
         y: Seq[(String, Attribute)]
     ) =>
-      parser.verifyCustomOp(
-        opGen = factory,
+      parser.generateOperation(
         opName = name,
-        resultNames = resNames,
-        resultTypes = (for { name <- resNames } yield TupleStream(Seq())),
-        dictAttrs = x,
-        dictProps = y
+        resultsNames = resNames,
+        resultsTypes = (for { name <- resNames } yield TupleStream(Seq())),
+        attributes = x,
+        properties = y
       )
   )
   // ==----------------------== //
@@ -258,15 +256,15 @@ object SelectionOp extends OperationObject {
         y: Region,
         z: Seq[(String, Attribute)]
     ) =>
-      parser.verifyCustomOp(
-        opGen = factory,
+      val operand_type = parser.currentScope.valueMap(x).typ
+      parser.generateOperation(
         opName = name,
-        operandNames = Seq(x),
-        resultNames = resNames,
-        resultTypes = (for { name <- resNames } yield TupleStream(Seq())),
+        operandsNames = Seq(x),
+        operandsTypes = Seq(operand_type),
+        resultsNames = resNames,
+        resultsTypes = (for { name <- resNames } yield TupleStream(Seq())),
         regions = Seq(y),
-        dictAttrs = z,
-        noForwardOperandRef = 1
+        attributes = z
       )
   )
   // ==----------------------== //
@@ -340,15 +338,15 @@ object MapOp extends OperationObject {
         y: Region,
         w: Seq[(String, Attribute)]
     ) =>
-      parser.verifyCustomOp(
-        opGen = factory,
+      val operand_type = parser.currentScope.valueMap(x).typ
+      parser.generateOperation(
         opName = name,
-        operandNames = Seq(x),
-        resultNames = resNames,
-        resultTypes = (for { name <- resNames } yield TupleStream(Seq())),
+        operandsNames = Seq(x),
+        operandsTypes = Seq(operand_type),
+        resultsNames = resNames,
+        resultsTypes = (for { name <- resNames } yield TupleStream(Seq())),
         regions = Seq(y),
-        dictAttrs = w :+ ("computed_cols", z),
-        noForwardOperandRef = 1
+        attributes = w :+ ("computed_cols", z)
       )
   )
   // ==----------------------== //
@@ -445,15 +443,15 @@ object AggregationOp extends OperationObject {
         y: Region,
         w: Seq[(String, Attribute)]
     ) =>
-      parser.verifyCustomOp(
-        opGen = factory,
+      val operand_type = parser.currentScope.valueMap(x).typ
+      parser.generateOperation(
         opName = name,
-        operandNames = Seq(x),
-        resultNames = resNames,
-        resultTypes = (for { name <- resNames } yield TupleStream(Seq())),
+        operandsNames = Seq(x),
+        operandsTypes = Seq(operand_type),
+        resultsNames = resNames,
+        resultsTypes = (for { name <- resNames } yield TupleStream(Seq())),
         regions = Seq(y),
-        dictAttrs = w :+ ("group_by_cols", reff) :+ ("computed_cols", deff),
-        noForwardOperandRef = 1
+        attributes = w :+ ("group_by_cols", reff) :+ ("computed_cols", deff)
       )
   )
   // ==----------------------== //
@@ -551,14 +549,14 @@ object CountRowsOp extends OperationObject {
         x: String,
         y: Seq[(String, Attribute)]
     ) =>
-      parser.verifyCustomOp(
-        opGen = factory,
+      val operand_type = parser.currentScope.valueMap(x).typ
+      parser.generateOperation(
         opName = name,
-        operandNames = Seq(x),
-        resultNames = resNames,
-        resultTypes = Seq(I64),
-        dictAttrs = y,
-        noForwardOperandRef = 1
+        operandsNames = Seq(x),
+        operandsTypes = Seq(operand_type),
+        resultsNames = resNames,
+        resultsTypes = Seq(I64),
+        attributes = y
       )
   )
   // ==----------------------== //
@@ -635,14 +633,14 @@ object AggrFuncOp extends OperationObject {
         resTypes: Seq[Attribute],
         y: Seq[(String, Attribute)]
     ) =>
-      parser.verifyCustomOp(
-        opGen = factory,
+      val operand_type = parser.currentScope.valueMap(x).typ
+      parser.generateOperation(
         opName = name,
-        operandNames = Seq(x),
-        resultNames = resNames,
-        resultTypes = resTypes,
-        dictAttrs = y :+ ("fn", aggrfunc) :+ ("attr", attr),
-        noForwardOperandRef = 1
+        operandsNames = Seq(x),
+        operandsTypes = Seq(operand_type),
+        resultsNames = resNames,
+        resultsTypes = resTypes,
+        attributes = y :+ ("fn", aggrfunc) :+ ("attr", attr)
       )
   )
   // ==----------------------== //
@@ -742,14 +740,14 @@ object SortOp extends OperationObject {
         attr: Attribute,
         y: Seq[(String, Attribute)]
     ) =>
-      parser.verifyCustomOp(
-        opGen = factory,
+      val operand_type = parser.currentScope.valueMap(x).typ
+      parser.generateOperation(
         opName = name,
-        operandNames = Seq(x),
-        resultNames = resNames,
-        resultTypes = (for { name <- resNames } yield TupleStream(Seq())),
-        dictAttrs = y :+ ("sortspecs", attr),
-        noForwardOperandRef = 1
+        operandsNames = Seq(x),
+        operandsTypes = Seq(operand_type),
+        resultsNames = resNames,
+        resultsTypes = (for { name <- resNames } yield TupleStream(Seq())),
+        attributes = y :+ ("sortspecs", attr)
       )
   )
   // ==----------------------== //
@@ -847,14 +845,14 @@ object MaterializeOp extends OperationObject {
         resTypes: Seq[Attribute],
         y: Seq[(String, Attribute)]
     ) =>
-      parser.verifyCustomOp(
-        opGen = factory,
+      val operand_type = parser.currentScope.valueMap(operand).typ
+      parser.generateOperation(
         opName = name,
-        operandNames = Seq(operand),
-        resultNames = resNames,
-        resultTypes = resTypes,
-        dictAttrs = y :+ ("cols", cols) :+ ("columns", columns),
-        noForwardOperandRef = 1
+        operandsNames = Seq(operand),
+        operandsTypes = Seq(operand_type),
+        resultsNames = resNames,
+        resultsTypes = resTypes,
+        attributes = y :+ ("cols", cols) :+ ("columns", columns)
       )
   )
   // ==----------------------== //

--- a/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
+++ b/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
@@ -140,7 +140,7 @@ private def DialectRegion[$: P](parser: Parser) = P(
     ~ (parser.BlockArgList.?.map(optionlessSeq).map(
       (x: Seq[(String, Attribute)]) => {
         val b = new Block(ListType.empty, ListType.from(x.map(_._2)))
-        Scope.defineValues(x.map(_._1) zip b.arguments)(parser.currentScope)
+        parser.currentScope.defineValues(x.map(_._1) zip b.arguments)
         b
       }
     )

--- a/dialects/src/main/scala-3/lingodb/SubOperatorOps.scala
+++ b/dialects/src/main/scala-3/lingodb/SubOperatorOps.scala
@@ -98,12 +98,11 @@ object SetResultOp extends OperationObject {
         z: Attribute,
         w: Seq[(String, Attribute)]
     ) =>
-      parser.verifyCustomOp(
-        opGen = factory,
+      parser.generateOperation(
         opName = name,
-        operandNames = Seq(y),
-        operandTypes = Seq(z),
-        dictAttrs = w :+ ("result_id", x)
+        operandsNames = Seq(y),
+        operandsTypes = Seq(z),
+        attributes = w :+ ("result_id", x)
       )
   )
   // ==----------------------== //

--- a/dialects/src/main/scala-3/lingodb/TupleStream.scala
+++ b/dialects/src/main/scala-3/lingodb/TupleStream.scala
@@ -147,12 +147,11 @@ object ReturnOp extends OperationObject {
       ~ ":" ~
       parser.Type.rep(sep = ",")).?.map(makeResults)
   ).map((x: Seq[(String, Attribute)], y: (Seq[String], Seq[Attribute])) =>
-    parser.verifyCustomOp(
-      opGen = constructOp,
+    parser.generateOperation(
       opName = name,
-      operandNames = y._1,
-      operandTypes = y._2,
-      dictAttrs = x
+      operandsNames = y._1,
+      operandsTypes = y._2,
+      attributes = x
     )
   )
   // ==----------------------== //
@@ -204,23 +203,23 @@ object GetColumnOp extends OperationObject {
       resNames: Seq[String],
       parser: Parser
   ): P[Operation] = P(
-    ValueId.rep(exactly = 1) ~ ColumnRefAttr.parse(parser) ~ ":" ~
+    ValueId ~ ColumnRefAttr.parse(parser) ~ ":" ~
       parser.Type ~ parser.DictionaryAttribute.?.map(Parser.optionlessSeq)
   ).map(
     (
-        x: Seq[String],
+        x: String,
         y: Attribute,
         z: Attribute,
         w: Seq[(String, Attribute)]
     ) =>
-      parser.verifyCustomOp(
-        opGen = factory,
+      val operand_type = parser.currentScope.valueMap(x).typ
+      parser.generateOperation(
         opName = name,
-        operandNames = x,
-        resultNames = resNames,
-        resultTypes = Seq(z),
-        dictAttrs = w :+ ("attr", y),
-        noForwardOperandRef = 1
+        operandsNames = Seq(x),
+        operandsTypes = Seq(operand_type),
+        resultsNames = resNames,
+        resultsTypes = Seq(z),
+        attributes = w :+ ("attr", y)
       )
   )
   // ==----------------------== //

--- a/dialects/src/main/scala-3/math/Math.scala
+++ b/dialects/src/main/scala-3/math/Math.scala
@@ -33,13 +33,12 @@ object AbsfOp extends OperationObject {
         )
       }
 
-      parser.verifyCustomOp(
-        opGen = AbsfOp.apply,
+      parser.generateOperation(
         opName = name,
-        operandNames = Seq(operandName),
-        operandTypes = Seq(type_),
-        resultNames = resNames,
-        resultTypes = Seq(type_)
+        operandsNames = Seq(operandName),
+        operandsTypes = Seq(type_),
+        resultsNames = resNames,
+        resultsTypes = Seq(type_)
       )
     }
   }
@@ -106,13 +105,12 @@ object FPowIOp extends OperationObject {
           )
         }
 
-        parser.verifyCustomOp(
-          opGen = FPowIOp.apply,
+        parser.generateOperation(
           opName = name,
-          operandNames = Seq(operand1Name, operand2Name),
-          operandTypes = Seq(operand1Type, operand2Type),
-          resultNames = resNames,
-          resultTypes = Seq(operand1Type)
+          operandsNames = Seq(operand1Name, operand2Name),
+          operandsTypes = Seq(operand1Type, operand2Type),
+          resultsNames = resNames,
+          resultsTypes = Seq(operand1Type)
         )
     }
   }


### PR DESCRIPTION
- Get rid of `verifyCustomOp`, use `generateOp` everywhere instead.
- Move static Scope method with implicit Scope parameters to being simple Scope methods.