### PR TITLE
Refactor results parsing and scope declaration.

### DIFF
--- a/core/src/main/scala-3/Parser.scala
+++ b/core/src/main/scala-3/Parser.scala
@@ -723,7 +723,7 @@ class Parser(val context: MLContext, val args: Args = Args())
             attributes: Seq[(String, Attribute)],
             operandsAndResultsTypes: (Seq[Attribute], Seq[Attribute])
         ) =>
-          val op = generateOperation(
+          generateOperation(
             opName,
             operandsNames,
             successorsNames,
@@ -733,7 +733,6 @@ class Parser(val context: MLContext, val args: Args = Args())
             operandsAndResultsTypes._2,
             operandsAndResultsTypes._1
           )
-          op
     ).tupled
   )
 

--- a/core/src/main/scala-3/builtin/Builtin.scala
+++ b/core/src/main/scala-3/builtin/Builtin.scala
@@ -465,15 +465,11 @@ object ModuleOp extends OperationObject {
 
   // ==--- Custom Parsing ---== //
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] =
-    if resNames != Nil then
-      throw new Exception("ModuleOp does not have results")
-    else
-      P(
-        parser.Region
-      ).map((x: Region) => ModuleOp(regions = ListType(x)))
+    P(
+      parser.Region
+    ).map((x: Region) => ModuleOp(regions = ListType(x)))
   // ==----------------------== //
 
 }

--- a/core/src/main/scala-3/representation/IR.scala
+++ b/core/src/main/scala-3/representation/IR.scala
@@ -465,7 +465,7 @@ class RegisteredOperation(
 trait OperationObject {
   def name: String
 
-  def parse[$: P](resNames: Seq[String], parser: Parser): P[Operation] =
+  def parse[$: P](parser: Parser): P[Operation] =
     throw new Exception(
       s"No custom Parser implemented for Operation '${name}'"
     )

--- a/core/src/main/scala-3/scairdl/IRElements.scala
+++ b/core/src/main/scala-3/scairdl/IRElements.scala
@@ -344,7 +344,6 @@ case class OperationDef(
 
     f"""
   override def parse[$$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = {
       P(
@@ -355,7 +354,6 @@ case class OperationDef(
             opName = name,
             operandsNames = Seq(${operandVars.mkString(", ")}),
             operandsTypes = Seq(${typeVars.mkString(", ")}),
-            resultsNames = resNames,
             resultsTypes = Seq(${resultVars.mkString(", ")})
           )
       }

--- a/dialects/src/main/scala-3/lingodb/DBOps.scala
+++ b/dialects/src/main/scala-3/lingodb/DBOps.scala
@@ -268,7 +268,6 @@ object DB_ConstantOp extends OperationObject {
 
   // ==--- Custom Parsing ---== //
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = P(
     "(" ~ parser.Type ~ ")" ~ ":" ~ parser.Type
@@ -281,7 +280,6 @@ object DB_ConstantOp extends OperationObject {
     ) =>
       parser.generateOperation(
         opName = name,
-        resultsNames = resNames,
         resultsTypes = Seq(y),
         attributes = z :+ ("value", x)
       )
@@ -340,7 +338,6 @@ object DB_CmpOp extends OperationObject {
 
   // ==--- Custom Parsing ---== //
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = P(
     DB_CmpPredicateAttr.caseParser ~ ValueId ~ ":" ~ parser.Type ~ "," ~ ValueId ~ ":" ~ parser.Type
@@ -356,7 +353,6 @@ object DB_CmpOp extends OperationObject {
     ) =>
       parser.generateOperation(
         opName = name,
-        resultsNames = resNames,
         resultsTypes = Seq(I1),
         operandsNames = Seq(left, right),
         operandsTypes = Seq(leftType, rightType),
@@ -485,7 +481,6 @@ object DB_MulOp extends OperationObject {
   }
 
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = P(
     ValueId ~ ":" ~ parser.Type ~ "," ~ ValueId ~ ":" ~ parser.Type
@@ -500,7 +495,6 @@ object DB_MulOp extends OperationObject {
     ) =>
       parser.generateOperation(
         opName = name,
-        resultsNames = resNames,
         resultsTypes = inferRetType(leftType, rightType),
         operandsNames = Seq(left, right),
         operandsTypes = Seq(leftType, rightType),
@@ -634,7 +628,6 @@ object DB_DivOp extends OperationObject {
   }
 
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = P(
     ValueId ~ ":" ~ parser.Type ~ "," ~ ValueId ~ ":" ~ parser.Type
@@ -651,7 +644,6 @@ object DB_DivOp extends OperationObject {
         opName = name,
         operandsNames = Seq(left, right),
         operandsTypes = Seq(leftType, rightType),
-        resultsNames = resNames,
         resultsTypes = inferRetType(leftType, rightType),
         attributes = z
       )
@@ -719,7 +711,6 @@ object DB_AddOp extends OperationObject {
 
   // ==--- Custom Parsing ---== //
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = P(
     ValueId ~ ":" ~ parser.Type ~ "," ~ ValueId ~ ":" ~ parser.Type
@@ -734,7 +725,6 @@ object DB_AddOp extends OperationObject {
     ) =>
       parser.generateOperation(
         opName = name,
-        resultsNames = resNames,
         resultsTypes = Seq(leftType),
         operandsNames = Seq(left, right),
         operandsTypes = Seq(leftType, rightType),
@@ -806,7 +796,6 @@ object DB_SubOp extends OperationObject {
 
   // ==--- Custom Parsing ---== //
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = P(
     ValueId ~ ":" ~ parser.Type ~ "," ~ ValueId ~ ":" ~ parser.Type
@@ -821,7 +810,6 @@ object DB_SubOp extends OperationObject {
     ) =>
       parser.generateOperation(
         opName = name,
-        resultsNames = resNames,
         resultsTypes = Seq(leftType),
         operandsNames = Seq(left, right),
         operandsTypes = Seq(leftType, rightType),
@@ -891,7 +879,6 @@ object CastOp extends OperationObject {
 
   // ==--- Custom Parsing ---== //
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = P(
     ValueId ~ ":" ~ parser.Type ~ "->" ~ parser.Type.rep
@@ -905,7 +892,6 @@ object CastOp extends OperationObject {
     ) =>
       parser.generateOperation(
         opName = name,
-        resultsNames = resNames,
         resultsTypes = resTypes,
         operandsNames = Seq(operand),
         operandsTypes = Seq(opType),

--- a/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
+++ b/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
@@ -161,7 +161,6 @@ object BaseTableOp extends OperationObject {
 
   // ==--- Custom Parsing ---== //
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ) = P(
     parser.DictionaryAttribute.?.map(Parser.optionlessSeq) ~
@@ -174,8 +173,7 @@ object BaseTableOp extends OperationObject {
     ) =>
       parser.generateOperation(
         opName = name,
-        resultsNames = resNames,
-        resultsTypes = (for { name <- resNames } yield TupleStream(Seq())),
+        resultsTypes = Seq(TupleStream(Seq())),
         attributes = x,
         properties = y
       )
@@ -243,7 +241,6 @@ object SelectionOp extends OperationObject {
 
   // ==--- Custom Parsing ---== //
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = P(
     ValueId ~ DialectRegion(parser)
@@ -261,8 +258,7 @@ object SelectionOp extends OperationObject {
         opName = name,
         operandsNames = Seq(x),
         operandsTypes = Seq(operand_type),
-        resultsNames = resNames,
-        resultsTypes = (for { name <- resNames } yield TupleStream(Seq())),
+        resultsTypes = Seq(TupleStream(Seq())),
         regions = Seq(y),
         attributes = z
       )
@@ -323,7 +319,6 @@ object MapOp extends OperationObject {
 
   // ==--- Custom Parsing ---== //
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = P(
     ValueId
@@ -343,8 +338,7 @@ object MapOp extends OperationObject {
         opName = name,
         operandsNames = Seq(x),
         operandsTypes = Seq(operand_type),
-        resultsNames = resNames,
-        resultsTypes = (for { name <- resNames } yield TupleStream(Seq())),
+        resultsTypes = Seq(TupleStream(Seq())),
         regions = Seq(y),
         attributes = w :+ ("computed_cols", z)
       )
@@ -420,7 +414,6 @@ object AggregationOp extends OperationObject {
 
   // ==--- Custom Parsing ---== //
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = P(
     ValueId
@@ -448,8 +441,7 @@ object AggregationOp extends OperationObject {
         opName = name,
         operandsNames = Seq(x),
         operandsTypes = Seq(operand_type),
-        resultsNames = resNames,
-        resultsTypes = (for { name <- resNames } yield TupleStream(Seq())),
+        resultsTypes = Seq(TupleStream(Seq())),
         regions = Seq(y),
         attributes = w :+ ("group_by_cols", reff) :+ ("computed_cols", deff)
       )
@@ -540,7 +532,6 @@ object CountRowsOp extends OperationObject {
 
   // ==--- Custom Parsing ---== //
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = P(
     ValueId ~ parser.DictionaryAttribute.?.map(Parser.optionlessSeq)
@@ -554,7 +545,6 @@ object CountRowsOp extends OperationObject {
         opName = name,
         operandsNames = Seq(x),
         operandsTypes = Seq(operand_type),
-        resultsNames = resNames,
         resultsTypes = Seq(I64),
         attributes = y
       )
@@ -619,7 +609,6 @@ object AggrFuncOp extends OperationObject {
 
   // ==--- Custom Parsing ---== //
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = P(
     RelAlg_AggrFunc.caseParser ~ ColumnRefAttr.parse(parser)
@@ -638,7 +627,6 @@ object AggrFuncOp extends OperationObject {
         opName = name,
         operandsNames = Seq(x),
         operandsTypes = Seq(operand_type),
-        resultsNames = resNames,
         resultsTypes = resTypes,
         attributes = y :+ ("fn", aggrfunc) :+ ("attr", attr)
       )
@@ -725,7 +713,6 @@ object SortOp extends OperationObject {
 
   // ==--- Custom Parsing ---== //
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = P(
     ValueId
@@ -745,8 +732,7 @@ object SortOp extends OperationObject {
         opName = name,
         operandsNames = Seq(x),
         operandsTypes = Seq(operand_type),
-        resultsNames = resNames,
-        resultsTypes = (for { name <- resNames } yield TupleStream(Seq())),
+        resultsTypes = Seq(TupleStream(Seq())),
         attributes = y :+ ("sortspecs", attr)
       )
   )
@@ -824,7 +810,6 @@ object MaterializeOp extends OperationObject {
 
   // ==--- Custom Parsing ---== //
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = P(
     ValueId
@@ -850,7 +835,6 @@ object MaterializeOp extends OperationObject {
         opName = name,
         operandsNames = Seq(operand),
         operandsTypes = Seq(operand_type),
-        resultsNames = resNames,
         resultsTypes = resTypes,
         attributes = y :+ ("cols", cols) :+ ("columns", columns)
       )

--- a/dialects/src/main/scala-3/lingodb/SubOperatorOps.scala
+++ b/dialects/src/main/scala-3/lingodb/SubOperatorOps.scala
@@ -86,7 +86,6 @@ object SetResultOp extends OperationObject {
 
   // ==--- Custom Parsing ---== //
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = P(
     parser.Type ~ ValueId ~ ":" ~ parser.Type

--- a/dialects/src/main/scala-3/lingodb/TupleStream.scala
+++ b/dialects/src/main/scala-3/lingodb/TupleStream.scala
@@ -138,7 +138,6 @@ object ReturnOp extends OperationObject {
   }
 
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = P(
     parser.DictionaryAttribute.?.map(Parser.optionlessSeq) ~ (ValueId.rep(sep =
@@ -200,7 +199,6 @@ object GetColumnOp extends OperationObject {
 
   // ==--- Custom Parsing ---== //
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = P(
     ValueId ~ ColumnRefAttr.parse(parser) ~ ":" ~
@@ -217,7 +215,6 @@ object GetColumnOp extends OperationObject {
         opName = name,
         operandsNames = Seq(x),
         operandsTypes = Seq(operand_type),
-        resultsNames = resNames,
         resultsTypes = Seq(z),
         attributes = w :+ ("attr", y)
       )

--- a/dialects/src/main/scala-3/math/Math.scala
+++ b/dialects/src/main/scala-3/math/Math.scala
@@ -5,7 +5,6 @@ import scair.Parser
 import scair.Parser.whitespace
 import scair.ir.*
 
-import scala.collection.immutable
 import scala.collection.mutable
 
 ////////////////
@@ -21,23 +20,15 @@ object AbsfOp extends OperationObject {
   override def factory: FactoryType = AbsfOp.apply
 
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = {
     P(
       "" ~ Parser.ValueUse ~ ":" ~ parser.Type
     ).map { case (operandName, type_) =>
-      if (resNames.length != 1) {
-        throw new Exception(
-          s"AbsfOp must produce exactly one result, but found ${resNames.length}."
-        )
-      }
-
       parser.generateOperation(
         opName = name,
         operandsNames = Seq(operandName),
         operandsTypes = Seq(type_),
-        resultsNames = resNames,
         resultsTypes = Seq(type_)
       )
     }
@@ -87,7 +78,6 @@ object FPowIOp extends OperationObject {
   override def factory = FPowIOp.apply
 
   override def parse[$: P](
-      resNames: Seq[String],
       parser: Parser
   ): P[Operation] = {
     P(
@@ -99,17 +89,10 @@ object FPowIOp extends OperationObject {
             operand1Type,
             operand2Type
           ) =>
-        if (resNames.length != 1) {
-          throw new Exception(
-            s"FPowIOp must produce exactly one result, but found ${resNames.length}."
-          )
-        }
-
         parser.generateOperation(
           opName = name,
           operandsNames = Seq(operand1Name, operand2Name),
           operandsTypes = Seq(operand1Type, operand2Type),
-          resultsNames = resNames,
           resultsTypes = Seq(operand1Type)
         )
     }


### PR DESCRIPTION
Make the core parser handle results scope-declaration out of `generateOperation`, so generically.
Hence, remove all related logic from the custom parsing hooks, and update all existing implementations.