### PR TITLE
Give type-level MLIR names, and forward throuf OperationDef to macros

### DIFF
--- a/clairV2/src/main/scala-3/CodeGen.scala
+++ b/clairV2/src/main/scala-3/CodeGen.scala
@@ -68,7 +68,6 @@ case class OpAttributeDef(
 \*≡==----=≡≡≡=----==≡*/
 
 case class OperationDef(
-    val dialect: String,
     val name: String,
     val className: String,
     val operands: Seq[OperandDef] = Seq(),

--- a/clairV2/test/src/scala-3/MacrosTest.scala
+++ b/clairV2/test/src/scala-3/MacrosTest.scala
@@ -13,7 +13,8 @@ case class MulV2(
     rhs: Operand[IntegerType],
     result: Result[IntegerType],
     randProp: Property[StringData]
-) derives MLIRTrait
+) extends MLIRName["cmath.mul"]
+    derives MLIRTrait
 
 case class MulFull(
     operand1: Operand[IntegerType],
@@ -26,14 +27,15 @@ case class MulFull(
     reg2: Region,
     succ1: Successor,
     succ2: Successor
-) derives MLIRTrait
+) extends MLIRName["cmath.mulfull"]
+    derives MLIRTrait
 
 class MacrosTest extends AnyFlatSpec with BeforeAndAfter {
 
   object TestCases {
 
     val unverOp = UnverifiedOp[MulV2](
-      name = "mulv2",
+      name = "cmath.mul",
       operands = ListType(
         Value[Attribute](typ = IntegerType(IntData(5), Unsigned)),
         Value[IntegerType](typ = IntegerType(IntData(5), Unsigned))
@@ -76,7 +78,7 @@ class MacrosTest extends AnyFlatSpec with BeforeAndAfter {
       dictionaryProperties = DictType(("randProp" -> StringData("what")))
     )
 
-    unverOp.name should be("mulv2")
+    unverOp.name should be("cmath.mul")
     unverOp.operands should matchPattern {
       case ListType(
             Value(IntegerType(IntData(5), Unsigned)),
@@ -97,7 +99,7 @@ class MacrosTest extends AnyFlatSpec with BeforeAndAfter {
     val op = TestCases.adtOp
     val unverOp = opT.unverify(op)
 
-    unverOp.name should be("mulv2")
+    unverOp.name should be("cmath.mul")
     unverOp.operands should matchPattern {
       case ListType(
             Value(IntegerType(IntData(5), Unsigned)),

--- a/core/src/main/scala-3/ir/Operation.scala
+++ b/core/src/main/scala-3/ir/Operation.scala
@@ -13,6 +13,8 @@ import scair.Printer
 // ██║ ██║░░██║
 // ╚═╝ ╚═╝░░╚═╝
 
+class MLIRName[name <: String]
+
 sealed abstract class Operation()
 
 class UnverifiedOp[T](

--- a/dialects/src/main/scala-3/cmathv2/CMathV2.scala
+++ b/dialects/src/main/scala-3/cmathv2/CMathV2.scala
@@ -11,11 +11,13 @@ case class MulV2(
     rhs: Operand[IntegerType],
     result: Result[IntegerType],
     randProp: Property[StringData]
-) derives MLIRTrait
+) extends MLIRName["cmathv2.mulv2"]
+    derives MLIRTrait
 
 case class NormV2(
     norm: Operand[IntegerType],
     result: Result[IntegerType]
-) derives MLIRTrait
+) extends MLIRName["cmathv2.normv2"]
+    derives MLIRTrait
 
 val CMathV2Dialect = summonDialect[(MulV2, NormV2)]

--- a/tests/filecheck/clairV2/mlir/first_test.mlir
+++ b/tests/filecheck/clairV2/mlir/first_test.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
     %0 = "test.op"() {hello = "world", "quoted" = i3298} : () -> (i32)
-    %1 = "normv2"(%0) : (i32) -> (i32)
+    %1 = "cmathv2.normv2"(%0) : (i32) -> (i32)
 }) : () -> ()
 
 // CHECK: builtin.module {
 // CHECK:   %0 = "test.op"() {hello = "world", quoted = i3298} : () -> (i32)
-// CHECK:   %1 = "normv2"(%0) : (i32) -> (i32)
+// CHECK:   %1 = "cmathv2.normv2"(%0) : (i32) -> (i32)
 // CHECK: }


### PR DESCRIPTION
As a demonstration of the style I would like to enforce in the macros!