### PR TITLE
Bring Scalafix back to the build.

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -11,7 +11,7 @@ import mill.scalalib.{ScalaModule, DepSyntax, scalafmt, UnidocModule, PublishMod
 import mill.scalalib.publish.{PomSettings, License, VersionControl}
 import mill.testrunner.TestResult
 import mill.resolve.{Resolve, SelectMode}
-import mill.define.{NamedTask, Command, ModuleRef}
+import mill.define.{NamedTask, Command, ModuleRef, Module}
 import mill.main.Tasks
 
 import scala.sys.process._
@@ -94,16 +94,27 @@ object `package` extends RootModule with ScairModule {
   def allScalaSources = Tasks(Resolve.Tasks.resolve(this, Seq("__.sources"), SelectMode.Multi).fold(sys.error(_), (tasks : List[NamedTask[_]]) => tasks.filter(_.isInstanceOf[NamedTask[Seq[PathRef]]]).map(_.asInstanceOf[NamedTask[Seq[PathRef]]])))
   def runAllUnitTests = T{T.sequence(Resolve.Tasks.resolve(this, Seq("__.test"), SelectMode.Multi).fold(sys.error(_), (tasks : List[NamedTask[_]]) => tasks.filter(_.isInstanceOf[NamedTask[(String, Seq[TestResult])]]).map(_.asInstanceOf[NamedTask[(String, Seq[TestResult])]])))()}
    
+  def allChildren = allChidrenRec(millModuleDirectChildren)
+  def allChidrenRec(children: Seq[Module]): Seq[Module] = {
+    children ++ children.flatMap(child => allChidrenRec(child.millModuleDirectChildren))
+  }
+
+  def scalafixAll(args: String*)= T.command {
+    T.sequence(allChildren
+      .flatMap{case m : ScalafixModule => Some(m.fix(args:_*))
+      case _ => None})()
+    }
+
   // Run all formatting on all sources in the framework
   def formatAll() = T.command {
-    fix()
-    scalafmt.ScalafmtModule.reformatAll(allScalaSources)
+    scalafixAll()()
+    scalafmt.ScalafmtModule.reformatAll(allScalaSources)()
   }
 
   // Run all formatting *checks* on all sources in the framework
   def checkFormatAll() = T.command {
-    fix("--check")
-    scalafmt.ScalafmtModule.checkFormatAll(allScalaSources)
+    scalafixAll("--check")()
+    scalafmt.ScalafmtModule.checkFormatAll(allScalaSources)()
   }
 
   // Define a testAll to run the full framework testing infrastructure

--- a/clair/src/main/scala-3/CV2Mirror.scala
+++ b/clair/src/main/scala-3/CV2Mirror.scala
@@ -1,15 +1,11 @@
 package scair.clair.mirrored
 
 import scair.clair.codegen.*
-import scair.clair.macros.*
 import scair.ir.*
 
-import scala.compiletime._
-import scala.deriving._
-
-import scala.Tuple.Zip
-import scala.collection.View.Empty
-import scala.quoted._
+import scala.compiletime.*
+import scala.deriving.*
+import scala.quoted.*
 
 // ░█████╗░ ██╗░░░░░ ░█████╗░ ██╗ ██████╗░ ██╗░░░██╗ ██████╗░
 // ██╔══██╗ ██║░░░░░ ██╔══██╗ ██║ ██╔══██╗ ██║░░░██║ ╚════██╗

--- a/clair/src/main/scala-3/CodeGen.scala
+++ b/clair/src/main/scala-3/CodeGen.scala
@@ -1,10 +1,7 @@
 package scair.clair.codegen
 
-import java.io.File
-import java.io.PrintStream
+import scala.quoted.*
 import scala.reflect.*
-import scair.ir._
-import scala.quoted._
 
 // ░█████╗░ ██╗░░░░░ ░█████╗░ ██╗ ██████╗░ ██╗░░░██╗ ██████╗░
 // ██╔══██╗ ██║░░░░░ ██╔══██╗ ██║ ██╔══██╗ ██║░░░██║ ╚════██╗

--- a/clair/src/main/scala-3/Macros.scala
+++ b/clair/src/main/scala-3/Macros.scala
@@ -10,6 +10,24 @@ import scala.collection.mutable
 import scala.compiletime.*
 import scala.quoted.*
 
+// ░█████╗░ ██╗░░░░░ ░█████╗░ ██╗ ██████╗░ ██╗░░░██╗ ██████╗░
+// ██╔══██╗ ██║░░░░░ ██╔══██╗ ██║ ██╔══██╗ ██║░░░██║ ╚════██╗
+// ██║░░╚═╝ ██║░░░░░ ███████║ ██║ ██████╔╝ ╚██╗░██╔╝ ░░███╔═╝
+// ██║░░██╗ ██║░░░░░ ██╔══██║ ██║ ██╔══██╗ ░╚████╔╝░ ██╔══╝░░
+// ╚█████╔╝ ███████╗ ██║░░██║ ██║ ██║░░██║ ░░╚██╔╝░░ ███████╗
+// ░╚════╝░ ╚══════╝ ╚═╝░░╚═╝ ╚═╝ ╚═╝░░╚═╝ ░░░╚═╝░░░ ╚══════╝
+
+// ███╗░░░███╗ ░█████╗░ ░█████╗░ ██████╗░ ░█████╗░ ░██████╗
+// ████╗░████║ ██╔══██╗ ██╔══██╗ ██╔══██╗ ██╔══██╗ ██╔════╝
+// ██╔████╔██║ ███████║ ██║░░╚═╝ ██████╔╝ ██║░░██║ ╚█████╗░
+// ██║╚██╔╝██║ ██╔══██║ ██║░░██╗ ██╔══██╗ ██║░░██║ ░╚═══██╗
+// ██║░╚═╝░██║ ██║░░██║ ╚█████╔╝ ██║░░██║ ╚█████╔╝ ██████╔╝
+// ╚═╝░░░░░╚═╝ ╚═╝░░╚═╝ ░╚════╝░ ╚═╝░░╚═╝ ░╚════╝░ ╚═════╝░
+
+/*≡==--==≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡==--=≡≡*\
+||  ADT to Unverified conversion Macro  ||
+\*≡==---==≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡==---==≡*/
+
 /** Small helper to select a member of an expression.
   * @param obj
   *   The object to select the member from.
@@ -333,14 +351,12 @@ def partitionedConstructs[Def <: OpInputDef: Type](
         getConstructVariadicity(d) match
           case Variadicity.Single => '{ ${ flat }(${ Expr(i) }) }
           case Variadicity.Variadic =>
-            val e = '{
+            '{
               val sizes = $segmentSizes
               val start = sizes.slice(0, ${ Expr(i) }).sum
               val end = start + sizes(${ Expr(i) })
               ${ flat }.slice(start, end)
             }
-            println(e.show)
-            e
       }
 
 /** Get all verified constructs of a specified type from an UnverifiedOp. That

--- a/clair/src/main/scala-3/Macros.scala
+++ b/clair/src/main/scala-3/Macros.scala
@@ -1,35 +1,13 @@
 package scair.clair.macros
 
-import scala.quoted.*
-import scair.ir.*
-import scala.collection.mutable
-import scair.scairdl.constraints.*
-import scair.dialects.builtin.*
-import scala.collection.mutable.ListBuffer
-
-import scala.compiletime._
+import scair.clair.codegen.*
 import scair.clair.mirrored.getDefImpl
-import scala.deriving.Mirror
-import scair.clair.codegen._
+import scair.dialects.builtin.*
+import scair.ir.*
+import scair.scairdl.constraints.*
 
-// ░█████╗░ ██╗░░░░░ ░█████╗░ ██╗ ██████╗░ ██╗░░░██╗ ██████╗░
-// ██╔══██╗ ██║░░░░░ ██╔══██╗ ██║ ██╔══██╗ ██║░░░██║ ╚════██╗
-// ██║░░╚═╝ ██║░░░░░ ███████║ ██║ ██████╔╝ ╚██╗░██╔╝ ░░███╔═╝
-// ██║░░██╗ ██║░░░░░ ██╔══██║ ██║ ██╔══██╗ ░╚████╔╝░ ██╔══╝░░
-// ╚█████╔╝ ███████╗ ██║░░██║ ██║ ██║░░██║ ░░╚██╔╝░░ ███████╗
-// ░╚════╝░ ╚══════╝ ╚═╝░░╚═╝ ╚═╝ ╚═╝░░╚═╝ ░░░╚═╝░░░ ╚══════╝
-
-// ███╗░░░███╗ ░█████╗░ ░█████╗░ ██████╗░ ░█████╗░ ░██████╗
-// ████╗░████║ ██╔══██╗ ██╔══██╗ ██╔══██╗ ██╔══██╗ ██╔════╝
-// ██╔████╔██║ ███████║ ██║░░╚═╝ ██████╔╝ ██║░░██║ ╚█████╗░
-// ██║╚██╔╝██║ ██╔══██║ ██║░░██╗ ██╔══██╗ ██║░░██║ ░╚═══██╗
-// ██║░╚═╝░██║ ██║░░██║ ╚█████╔╝ ██║░░██║ ╚█████╔╝ ██████╔╝
-// ╚═╝░░░░░╚═╝ ╚═╝░░╚═╝ ░╚════╝░ ╚═╝░░╚═╝ ░╚════╝░ ╚═════╝░
-
-/*≡==--==≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡==--=≡≡*\
-||  ADT to Unverified conversion Macro  ||
-\*≡==---==≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡==---==≡*/
-
+import scala.collection.mutable
+import scala.compiletime.*
 import scala.quoted.*
 
 /** Small helper to select a member of an expression.
@@ -59,7 +37,6 @@ def ADTFlatInputMacro[Def <: OpInputDef: Type](
     opInputDefs: Seq[Def],
     adtOpExpr: Expr[_]
 )(using Quotes): Expr[ListType[DefinedInput[Def]]] = {
-  import quotes.reflect.*
   val stuff = Expr.ofList(
     opInputDefs.map((d: Def) =>
       getConstructVariadicity(d) match
@@ -91,7 +68,6 @@ def fromADTOperationMacro[T: Type](
 )(using
     Quotes
 ): Expr[UnverifiedOp[T]] =
-  import quotes.reflect.*
 
   /*______________*\
   \*-- OPERANDS --*/

--- a/core/src/main/scala-3/builtin/Builtin.scala
+++ b/core/src/main/scala-3/builtin/Builtin.scala
@@ -3,6 +3,7 @@ package scair.dialects.builtin
 import fastparse.*
 import scair.Parser
 import scair.Printer
+import scair.core.macros.*
 import scair.dialects.affine.AffineMap
 import scair.dialects.affine.AffineSet
 import scair.exceptions.VerifyException
@@ -12,7 +13,6 @@ import scair.scairdl.constraints.ConstraintContext
 
 import scala.collection.immutable
 import scala.collection.mutable
-import scair.core.macros._
 
 // ██████╗░ ██╗░░░██╗ ██╗ ██╗░░░░░ ████████╗ ██╗ ███╗░░██╗
 // ██╔══██╗ ██║░░░██║ ██║ ██║░░░░░ ╚══██╔══╝ ██║ ████╗░██║

--- a/core/src/main/scala-3/macros/TransparentData.scala
+++ b/core/src/main/scala-3/macros/TransparentData.scala
@@ -1,7 +1,8 @@
 package scair.core.macros
 
-import scala.quoted._
 import scair.ir.DataAttribute
+
+import scala.quoted.*
 
 /** Type helper to extract the type of the data from the DataAttribute.
   */

--- a/dialects/src/main/scala-3/affine/Affine.scala
+++ b/dialects/src/main/scala-3/affine/Affine.scala
@@ -1,12 +1,9 @@
 package scair.dialects.affine
 
-import scair.dialects.builtin.*
-import scair.ir.Attribute
 import scair.clair.codegen.*
-import scair.clair.mirrored.*
+import scair.clair.macros.*
 import scair.dialects.builtin.*
 import scair.ir.*
-import scair.clair.macros._
 
 // ░█████╗░ ███████╗ ███████╗ ██╗ ███╗░░██╗ ███████╗
 // ██╔══██╗ ██╔════╝ ██╔════╝ ██║ ████╗░██║ ██╔════╝

--- a/dialects/src/main/scala-3/arith/Arith.scala
+++ b/dialects/src/main/scala-3/arith/Arith.scala
@@ -2,14 +2,14 @@ package scair.dialects.arith
 
 import fastparse.*
 import scair.AttrParser
+import scair.clair.codegen.*
+import scair.clair.macros.*
 import scair.dialects.builtin.FloatType
 import scair.dialects.builtin.IntegerAttr
 import scair.dialects.builtin.IntegerType
-import scala.collection.immutable.*
-import scair.clair.codegen.*
-import scair.clair.mirrored.*
 import scair.ir.*
-import scair.clair.macros._
+
+import scala.collection.immutable.*
 
 // TODO: Upstream Arith natively support vector or other containers of it's operands and results type
 // i.e., add vectors not just integers.

--- a/dialects/src/main/scala-3/cmath/CMath.scala
+++ b/dialects/src/main/scala-3/cmath/CMath.scala
@@ -1,8 +1,7 @@
 package scair.dialects.cmath
 
 import scair.clair.codegen.*
-import scair.clair.mirrored.*
-import scair.clair.macros._
+import scair.clair.macros.*
 import scair.dialects.builtin.*
 import scair.ir.*
 

--- a/dialects/src/main/scala-3/func/Func.scala
+++ b/dialects/src/main/scala-3/func/Func.scala
@@ -1,13 +1,9 @@
 package scair.dialects.func
 
-import scair.dialects.builtin.*
-import scair.ir.Attribute
-import scair.ir.*
 import scair.clair.codegen.*
-import scair.clair.mirrored.*
+import scair.clair.macros.*
 import scair.dialects.builtin.*
 import scair.ir.*
-import scair.clair.macros._
 
 case class Call(
     callee: Property[SymbolRefAttr],

--- a/dialects/src/main/scala-3/llvm/LLVM.scala
+++ b/dialects/src/main/scala-3/llvm/LLVM.scala
@@ -1,12 +1,9 @@
 package scair.dialects.llvm
 
-import scair.dialects.builtin.DenseArrayAttr
-import scair.dialects.builtin.IntegerType
 import scair.clair.codegen.*
-import scair.clair.mirrored.*
+import scair.clair.macros.*
 import scair.dialects.builtin.*
 import scair.ir.*
-import scair.clair.macros._
 
 object Ptr extends AttributeObject {
   override def name: String = "llvm.ptr"

--- a/dialects/src/main/scala-3/memref/Memref.scala
+++ b/dialects/src/main/scala-3/memref/Memref.scala
@@ -1,14 +1,9 @@
 package scair.dialects.memref
 
-import scair.dialects.builtin.IndexType
-import scair.dialects.builtin.IntegerAttr
-import scair.dialects.builtin.MemrefType
-import scair.ir.*
 import scair.clair.codegen.*
-import scair.clair.mirrored.*
+import scair.clair.macros.*
 import scair.dialects.builtin.*
 import scair.ir.*
-import scair.clair.macros._
 
 case class Alloc(
     dynamicSizes: Variadic[Operand[IndexType.type]],

--- a/tools/src/main/scala-3/ScairOpt.scala
+++ b/tools/src/main/scala-3/ScairOpt.scala
@@ -12,7 +12,6 @@ import scala.io.Source
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
-import scala.Either
 
 object ScairOpt {
 

--- a/transformations/src/main/scala-3/CMathDummyTransformation.scala
+++ b/transformations/src/main/scala-3/CMathDummyTransformation.scala
@@ -1,8 +1,6 @@
 package scair.transformations.cdt
 
 import scair.dialects.builtin.StringData
-import scair.dialects.cmath.Mul
-import scair.dialects.cmath.Norm
 import scair.ir.*
 import scair.transformations.ModulePass
 import scair.transformations.PatternRewriteWalker


### PR DESCRIPTION
Hooked into `formatAll` & `checkFormatAll`, so should be transparent for users and CI!

Cleans up a bit of our unused imports, and clears out a few related warning!