### PR TITLE
Cleanup low-hanging warnings.

### DIFF
--- a/clair/src/main/scala-3/CV2Mirror.scala
+++ b/clair/src/main/scala-3/CV2Mirror.scala
@@ -138,7 +138,7 @@ def getDefImpl[T: Type](using quotes: Quotes): OperationDef =
           Type.valueOfConstant[name].get.asInstanceOf[String]
 
       val inputs = Type.of[(elemLabels, elemTypes)] match
-        case _: Type[(Tuple, Tuple)] => summonInput[elemLabels, elemTypes]
+        case '[(Tuple, Tuple)] => summonInput[elemLabels, elemTypes]
       val e = OperationDef(
         name = name,
         className = defname,

--- a/core/src/main/scala-3/builtin/AttrParser.scala
+++ b/core/src/main/scala-3/builtin/AttrParser.scala
@@ -124,14 +124,16 @@ class AttrParser(val ctx: MLContext) {
         IntegerAttr(
           x,
           y match {
-            case yy: Some[_] => yy.get match
-              case i: IntegerType => i
-              case IndexType   => IndexType
-              case _ => throw new Exception(
-                s"Unreachable, fastparse's | is simply weakly typed."
-              )
-            
-            case None                                   => I64
+            case yy: Some[_] =>
+              yy.get match
+                case i: IntegerType => i
+                case IndexType      => IndexType
+                case _ =>
+                  throw new Exception(
+                    s"Unreachable, fastparse's | is simply weakly typed."
+                  )
+
+            case None => I64
           }
         )
       )

--- a/core/src/main/scala-3/builtin/AttrParser.scala
+++ b/core/src/main/scala-3/builtin/AttrParser.scala
@@ -124,7 +124,13 @@ class AttrParser(val ctx: MLContext) {
         IntegerAttr(
           x,
           y match {
-            case yy: Some[IntegerType | IndexType.type] => yy.get
+            case yy: Some[_] => yy.get match
+              case i: IntegerType => i
+              case IndexType   => IndexType
+              case _ => throw new Exception(
+                s"Unreachable, fastparse's | is simply weakly typed."
+              )
+            
             case None                                   => I64
           }
         )

--- a/core/src/main/scala-3/builtin/Builtin.scala
+++ b/core/src/main/scala-3/builtin/Builtin.scala
@@ -319,24 +319,15 @@ case class SymbolRefAttr(
 \*≡==---==≡≡==---==≡*/
 
 case class DenseArrayAttr(
-    val typ: Attribute,
-    val data: Seq[Attribute]
+    val typ: IntegerType | FloatType,
+    val data: Seq[IntegerAttr] | Seq[FloatAttr]
 ) extends ParametrizedAttribute("builtin.dense", Seq(typ, data))
     with Seq[Attribute] {
 
   override def custom_verify(): Unit =
-    typ match {
-      case _: IntegerType | _: FloatType => ()
-      case _ =>
-        throw new VerifyException(
-          "Element type is not an integer or float type"
-        )
-    }
     if !data.forall(_ match {
         case IntegerAttr(_, eltyp) => eltyp == typ
         case FloatAttr(_, eltyp)   => eltyp == typ
-        case _ =>
-          throw new VerifyException("Element type is not an integer or float")
       })
     then
       throw new VerifyException(

--- a/core/src/main/scala-3/ir/Attribute.scala
+++ b/core/src/main/scala-3/ir/Attribute.scala
@@ -30,7 +30,7 @@ trait TypeAttribute extends Attribute {
 extension (x: Seq[Attribute] | Attribute)
 
   def custom_print: String = x match {
-    case seq: Seq[Attribute] => seq.map(_.custom_print).mkString("[", ", ", "]")
+    case x : Seq[_] => x.asInstanceOf[Seq[Attribute]].map(_.custom_print).mkString("[", ", ", "]")
     case attr: Attribute     => attr.custom_print
   }
 
@@ -72,7 +72,7 @@ abstract class DataAttribute[D](
 
   override def equals(attr: Any): Boolean = {
     attr match {
-      case x: DataAttribute[D] =>
+      case x: DataAttribute[_] =>
         x.name == this.name &&
         x.getClass == this.getClass &&
         x.data == this.data

--- a/core/src/main/scala-3/ir/Attribute.scala
+++ b/core/src/main/scala-3/ir/Attribute.scala
@@ -30,8 +30,11 @@ trait TypeAttribute extends Attribute {
 extension (x: Seq[Attribute] | Attribute)
 
   def custom_print: String = x match {
-    case x : Seq[_] => x.asInstanceOf[Seq[Attribute]].map(_.custom_print).mkString("[", ", ", "]")
-    case attr: Attribute     => attr.custom_print
+    case x: Seq[_] =>
+      x.asInstanceOf[Seq[Attribute]]
+        .map(_.custom_print)
+        .mkString("[", ", ", "]")
+    case attr: Attribute => attr.custom_print
   }
 
 abstract class ParametrizedAttribute(

--- a/core/src/main/scala-3/ir/Block.scala
+++ b/core/src/main/scala-3/ir/Block.scala
@@ -67,12 +67,13 @@ case class Block private (
   ) =
     this(
       ListType.from((arguments_types match {
-        case single: Attribute             => Seq(single)
+        case single: Attribute     => Seq(single)
         case multiple: Iterable[_] => multiple.asInstanceOf[Iterable[Attribute]]
       }).map(Value(_))),
       ListType.from((operations match {
-        case single: MLIROperation             => Seq(single)
-        case multiple: Iterable[_] => multiple.asInstanceOf[Iterable[MLIROperation]]
+        case single: MLIROperation => Seq(single)
+        case multiple: Iterable[_] =>
+          multiple.asInstanceOf[Iterable[MLIROperation]]
       }))
     )
 
@@ -91,12 +92,14 @@ case class Block private (
   ) =
     this(
       ListType.from(args._1 match {
-        case single: Value[Attribute]             => Seq(single)
-        case multiple: Iterable[_] => multiple.asInstanceOf[Iterable[Value[Attribute]]]
+        case single: Value[Attribute] => Seq(single)
+        case multiple: Iterable[_] =>
+          multiple.asInstanceOf[Iterable[Value[Attribute]]]
       }),
       ListType.from(args._2 match {
-        case single: MLIROperation             => Seq(single)
-        case multiple: Iterable[_] => multiple.asInstanceOf[Iterable[MLIROperation]]
+        case single: MLIROperation => Seq(single)
+        case multiple: Iterable[_] =>
+          multiple.asInstanceOf[Iterable[MLIROperation]]
       })
     )
 

--- a/core/src/main/scala-3/ir/Block.scala
+++ b/core/src/main/scala-3/ir/Block.scala
@@ -68,11 +68,11 @@ case class Block private (
     this(
       ListType.from((arguments_types match {
         case single: Attribute             => Seq(single)
-        case multiple: Iterable[Attribute] => multiple
+        case multiple: Iterable[_] => multiple.asInstanceOf[Iterable[Attribute]]
       }).map(Value(_))),
       ListType.from((operations match {
         case single: MLIROperation             => Seq(single)
-        case multiple: Iterable[MLIROperation] => multiple
+        case multiple: Iterable[_] => multiple.asInstanceOf[Iterable[MLIROperation]]
       }))
     )
 
@@ -92,11 +92,11 @@ case class Block private (
     this(
       ListType.from(args._1 match {
         case single: Value[Attribute]             => Seq(single)
-        case multiple: Iterable[Value[Attribute]] => multiple
+        case multiple: Iterable[_] => multiple.asInstanceOf[Iterable[Value[Attribute]]]
       }),
       ListType.from(args._2 match {
         case single: MLIROperation             => Seq(single)
-        case multiple: Iterable[MLIROperation] => multiple
+        case multiple: Iterable[_] => multiple.asInstanceOf[Iterable[MLIROperation]]
       })
     )
 

--- a/core/src/main/scala-3/scairdl/Constraints.scala
+++ b/core/src/main/scala-3/scairdl/Constraints.scala
@@ -368,7 +368,7 @@ case class ParametrizedAttrConstraint[T <: Attribute: ClassTag](
             for ((p, c) <- x.parameters zip constraints)
               p match {
                 case p: Attribute      => c.verify(p, constraint_ctx)
-                case p: Seq[Attribute] => c.verify(p, constraint_ctx)
+                case p: Seq[_] => c.verify(p.asInstanceOf[Seq[Attribute]], constraint_ctx)
               }
 
           case _ =>

--- a/core/src/main/scala-3/scairdl/Constraints.scala
+++ b/core/src/main/scala-3/scairdl/Constraints.scala
@@ -367,8 +367,9 @@ case class ParametrizedAttrConstraint[T <: Attribute: ClassTag](
             }
             for ((p, c) <- x.parameters zip constraints)
               p match {
-                case p: Attribute      => c.verify(p, constraint_ctx)
-                case p: Seq[_] => c.verify(p.asInstanceOf[Seq[Attribute]], constraint_ctx)
+                case p: Attribute => c.verify(p, constraint_ctx)
+                case p: Seq[_] =>
+                  c.verify(p.asInstanceOf[Seq[Attribute]], constraint_ctx)
               }
 
           case _ =>

--- a/core/src/main/scala-3/scairdl/IRElements.scala
+++ b/core/src/main/scala-3/scairdl/IRElements.scala
@@ -175,13 +175,13 @@ object NewParser {
   def operandDirective[$: P]: P[OperandDirective] =
     P("$" ~ CharsWhileIn("a-zA-Z0-9_").!)
       .filter(_ != "result")
-      .map(OperandDirective)
+      .map(OperandDirective(_))
 
   def typeDirective[$: P]: P[TypeDirective] =
-    P("type(" ~ (operandDirective) ~ ")").map(TypeDirective)
+    P("type(" ~ (operandDirective) ~ ")").map(TypeDirective(_))
 
   def literalDirective[$: P]: P[LiteralDirective] =
-    P(CharIn("`,:").!).map(LiteralDirective)
+    P(CharIn("`,:").!).map(LiteralDirective(_))
 
   def formatDirective[$: P]: P[FormatDirective] =
     P(typeDirective | operandDirective | literalDirective | resultTypeDirective)

--- a/core/src/main/scala-3/transformations/PatternRewriter.scala
+++ b/core/src/main/scala-3/transformations/PatternRewriter.scala
@@ -111,10 +111,11 @@ object RewriteMethods {
 
     val operations = ops match {
       case x: MLIROperation      => Seq(x)
-      case y: Seq[MLIROperation] => y
+      case y: Seq[_] => y.asInstanceOf[Seq[MLIROperation]]
     }
+    val operations2 = Seq.iterableFactory
     insertion_point.insert_before match {
-      case Some(op) =>
+      case Some(op) =>  
         insertion_point.block.insert_ops_before(
           op,
           operations
@@ -152,7 +153,7 @@ object RewriteMethods {
 
     val ops = new_ops match {
       case x: MLIROperation      => Seq(x)
-      case y: Seq[MLIROperation] => y
+      case y: Seq[_] => y.asInstanceOf[Seq[MLIROperation]]
     }
 
     val results = new_results match {

--- a/core/src/main/scala-3/transformations/PatternRewriter.scala
+++ b/core/src/main/scala-3/transformations/PatternRewriter.scala
@@ -110,12 +110,12 @@ object RewriteMethods {
   ): Unit = {
 
     val operations = ops match {
-      case x: MLIROperation      => Seq(x)
-      case y: Seq[_] => y.asInstanceOf[Seq[MLIROperation]]
+      case x: MLIROperation => Seq(x)
+      case y: Seq[_]        => y.asInstanceOf[Seq[MLIROperation]]
     }
     val operations2 = Seq.iterableFactory
     insertion_point.insert_before match {
-      case Some(op) =>  
+      case Some(op) =>
         insertion_point.block.insert_ops_before(
           op,
           operations
@@ -152,8 +152,8 @@ object RewriteMethods {
     }
 
     val ops = new_ops match {
-      case x: MLIROperation      => Seq(x)
-      case y: Seq[_] => y.asInstanceOf[Seq[MLIROperation]]
+      case x: MLIROperation => Seq(x)
+      case y: Seq[_]        => y.asInstanceOf[Seq[MLIROperation]]
     }
 
     val results = new_results match {


### PR DESCRIPTION
- We had a lot of warnings for
  ```scala
  case attr : Seq[T]
  ```
  Because `T` erased at runtime.

  Those are done to handle `T | Seq[T]` for nicer API; but this doesn't work out nicely, cause nothing tells that `T` isn't a `Seq`.
Replaced by `Seq[_]` for clean pattern definition, and the case code does `.asInstanceOf[Seq[T]]`. It's bad practice, yes, but the whole thing is and it is now explicit, putting the compiler at peace :slightly_smiling_face: 

  This pattern is a common Scala rabbit hole, we should consider it at some point, but let's just see when we have this time or actually need to! 

- A couple of warnings are left in the macros. I consider those less simple and actually a shorter-term good thing to figure out for the codegen!