### PR TITLE
[?] Attempt term designators for constraints

### DIFF
--- a/clair/src/main/scala-3/Constraints.scala
+++ b/clair/src/main/scala-3/Constraints.scala
@@ -1,0 +1,49 @@
+package scair.clair.constraint
+
+import scair.ir.Attribute
+import scala.quoted._
+
+trait Constraint[Bound <: Attribute] {
+    type T = Bound
+    def verification(attr : Expr[Bound])(using Quotes, Type[Bound]): Expr[Option[Bound]] =
+        '{Some($attr)}
+}
+
+class AnyAttr extends Constraint[Attribute] {
+}
+
+// Useless by design?
+class BaseAttr[T <: Attribute] extends Constraint[T] {
+}
+
+
+class EqualAttr[T <: Attribute](to : T) extends Constraint[T] {
+    override def verification(attr: Expr[T])(using Quotes, Type[T]): Expr[Option[T]] =
+        '{
+            $attr match
+                case to => Some($attr)
+                case _ => None
+        }
+}
+
+class AnyOf[T <: Attribute](of : T*) extends Constraint[T]{
+    override def verification(attr: Expr[T])(using Quotes, Type[T]): Expr[Option[T]] =
+        of match
+            case Nil => '{None}
+            case h :: t =>
+                '{
+                    $attr match
+                        case h => Some($attr)
+                        case or => ${AnyOf(t:_*).verification(attr)}
+                }
+        
+        '{
+            $attr match
+                case of => Some($attr)
+                case or => None
+        }
+
+}
+trait Constrained[T <: Constraint[_]] extends Attribute {
+    // val constraint: Constraint[T]
+}

--- a/core/src/main/scala-3/ir/Attribute.scala
+++ b/core/src/main/scala-3/ir/Attribute.scala
@@ -15,7 +15,7 @@ import scair.Parser.*
 ||    ATTRIBUTES    ||
 \*≡==---==≡≡==---==≡*/
 
-sealed trait Attribute {
+trait Attribute {
   def name: String
   def prefix: String = "#"
   def custom_verify(): Unit = ()

--- a/dialects/src/main/scala-3/cmath/CMath.scala
+++ b/dialects/src/main/scala-3/cmath/CMath.scala
@@ -4,6 +4,7 @@ import scair.clair.codegen.*
 import scair.clair.macros.*
 import scair.dialects.builtin.*
 import scair.ir.*
+import scair.clair.constraint._
 
 case class Complex(
     val typ: FloatType | IndexType.type
@@ -15,8 +16,9 @@ case class Complex(
     with MLIRName["cmath.complex"]
     derives AttributeTrait
 
+object cstr extends BaseAttr[Complex]
 case class Norm(
-    in: Operand[Complex],
+    in: Operand[Constrained[cstr.type]],
     res: Result[FloatType]
 ) extends MLIRName["cmath.norm"]
     derives MLIRTrait


### PR DESCRIPTION
One way to try hooking constraints through [Term Designators](https://scala-lang.org/files/archive/spec/3.4/03-types.html#term-designators)

Observations: 
- If we want to use the designated term's value at compile-time, it needs to be defined at least in another file (It's compilation must be completed before its usage - not sure that is even *sufficient* at this point)