### PR TITLE
DerivedOperation

### DIFF
--- a/clair/src/main/scala-3/Macros.scala
+++ b/clair/src/main/scala-3/Macros.scala
@@ -591,9 +591,13 @@ trait MLIRName[name <: String]
 
 object DerivedOperationCompanion {
 
-  inline def derived[T]: DerivedOperationCompanion[T] = ${ derivedImpl[T] }
+  inline def derived[T <: Operation]: DerivedOperationCompanion[T] = ${
+    derivedImpl[T]
+  }
 
-  def derivedImpl[T: Type](using Quotes): Expr[DerivedOperationCompanion[T]] =
+  def derivedImpl[T <: Operation: Type](using
+      Quotes
+  ): Expr[DerivedOperationCompanion[T]] =
     val opDef = getDefImpl[T]
 
     '{
@@ -632,10 +636,7 @@ object DerivedOperationCompanion {
           attributes = attributes
         )
 
-        // TODO: clean this up
-        // getDef would fail if T was not a DerivedOperation AKA Operation.
-        // This (T & Operation) is just the cleanest way I found for this agree to use T's inherited attributes field for now.
-        def unverify(adtOp: T & Operation): UnverifiedOp[T] =
+        def unverify(adtOp: T): UnverifiedOp[T] =
           val x = UnverifiedOp[T](
             name = ${ Expr(opDef.name) },
             operands = operands(adtOp),

--- a/clair/src/main/scala-3/Macros.scala
+++ b/clair/src/main/scala-3/Macros.scala
@@ -658,14 +658,13 @@ object DerivedOperationCompanion {
 inline def summonAttributeTraits[T <: Tuple]: Seq[AttributeTrait[?]] =
   inline erasedValue[T] match
     case _: (t *: ts) =>
-      // slight workaround on that &: TODO -> get rid of it ;)
-      AttributeTrait.derived[t] +: summonAttributeTraits[ts]
+      summonInline[AttributeTrait[t]] +: summonAttributeTraits[ts]
     case _: EmptyTuple => Seq()
 
 inline def summonMLIRTraits[T <: Tuple]: Seq[DerivedOperationCompanion[?]] =
   inline erasedValue[T] match
     case _: (t *: ts) =>
-      DerivedOperationCompanion.derived[t] +: summonMLIRTraits[ts]
+      summonInline[DerivedOperationCompanion[t]] +: summonMLIRTraits[ts]
     case _: EmptyTuple => Seq()
 
 inline def summonDialect[Attributes <: Tuple, Operations <: Tuple](

--- a/clair/src/main/scala-3/Macros.scala
+++ b/clair/src/main/scala-3/Macros.scala
@@ -574,6 +574,7 @@ trait DerivedOperation[name <: String, T] extends Operation {
   given companion: DerivedOperationCompanion[T] = deferred
 
   def name: String = companion.name
+  // TODO: refactor this to have efficient generic accessors here and combine that in unverify instead.
   def operands: ListType[Value[Attribute]] = companion.unverify(this).operands
   def successors: ListType[Block] = companion.unverify(this).successors
   def results: ListType[Result[Attribute]] = companion.unverify(this).results

--- a/clair/test/src/scala-3/MacrosTest.scala
+++ b/clair/test/src/scala-3/MacrosTest.scala
@@ -15,7 +15,7 @@ case class Mul(
     rhs: Operand[IntegerType],
     result: Result[IntegerType],
     randProp: StringData
-) extends MLIRName["cmath.mul"]
+) extends DerivedOperation["cmath.mul", Mul]
     derives DerivedOperationCompanion
 
 case class MulSingleVariadic(
@@ -23,7 +23,7 @@ case class MulSingleVariadic(
     rhs: Seq[Operand[IntegerType]],
     result: Seq[Result[IntegerType]],
     randProp: StringData
-) extends MLIRName["cmath.mulsinglevariadic"]
+) extends DerivedOperation["cmath.mulsinglevariadic", MulSingleVariadic]
     derives DerivedOperationCompanion
 
 case class MulMultiVariadic(
@@ -35,7 +35,7 @@ case class MulMultiVariadic(
     result3: Seq[Result[IntegerType]],
     operandSegmentSizes: DenseArrayAttr,
     resultSegmentSizes: DenseArrayAttr
-) extends MLIRName["cmath.mulmultivariadic"]
+) extends DerivedOperation["cmath.mulmultivariadic", MulMultiVariadic]
     derives DerivedOperationCompanion
 
 case class MulFull(
@@ -49,7 +49,7 @@ case class MulFull(
     reg2: Region,
     succ1: Successor,
     succ2: Successor
-) extends MLIRName["cmath.mulfull"]
+) extends DerivedOperation["cmath.mulfull", MulFull]
     derives DerivedOperationCompanion
 
 class MacrosTest extends AnyFlatSpec with BeforeAndAfter {
@@ -63,7 +63,7 @@ class MacrosTest extends AnyFlatSpec with BeforeAndAfter {
         Value[IntegerType](typ = IntegerType(IntData(5), Unsigned))
       ),
       results_types = ListType[Attribute](IntegerType(IntData(25), Unsigned)),
-      dictionaryProperties = DictType(("randProp" -> StringData("what")))
+      properties = DictType(("randProp" -> StringData("what")))
     )
 
     val adtMulOp = Mul(
@@ -97,7 +97,7 @@ class MacrosTest extends AnyFlatSpec with BeforeAndAfter {
         IntegerType(IntData(25), Unsigned),
         IntegerType(IntData(25), Unsigned)
       ),
-      dictionaryProperties = DictType(("randProp" -> StringData("what")))
+      properties = DictType(("randProp" -> StringData("what")))
     )
 
     val adtMulSinVarOp = MulSingleVariadic(
@@ -131,7 +131,7 @@ class MacrosTest extends AnyFlatSpec with BeforeAndAfter {
         IntegerType(IntData(25), Unsigned),
         IntegerType(IntData(25), Unsigned)
       ),
-      dictionaryProperties = DictType(
+      properties = DictType(
         ("operandSegmentSizes" -> DenseArrayAttr(
           IntegerType(IntData(32), Signless),
           Seq[IntegerAttr](
@@ -201,7 +201,7 @@ class MacrosTest extends AnyFlatSpec with BeforeAndAfter {
         Value[IntegerType](typ = IntegerType(IntData(5), Unsigned))
       ),
       results_types = ListType[Attribute](IntegerType(IntData(25), Unsigned)),
-      dictionaryProperties = DictType(("randProp" -> StringData("what")))
+      properties = DictType(("randProp" -> StringData("what")))
     )
 
     unverMulOp.name should be("cmath.mul")
@@ -214,7 +214,7 @@ class MacrosTest extends AnyFlatSpec with BeforeAndAfter {
     unverMulOp.results should matchPattern {
       case ListType(Result(IntegerType(IntData(25), Unsigned))) =>
     }
-    unverMulOp.dictionaryProperties("randProp") should matchPattern {
+    unverMulOp.properties("randProp") should matchPattern {
       case StringData("what") =>
     }
   }
@@ -235,7 +235,7 @@ class MacrosTest extends AnyFlatSpec with BeforeAndAfter {
     unverMulOp.results should matchPattern {
       case ListType(Result(IntegerType(IntData(25), Unsigned))) =>
     }
-    unverMulOp.dictionaryProperties("randProp") should matchPattern {
+    unverMulOp.properties("randProp") should matchPattern {
       case StringData("what") =>
     }
   }
@@ -271,10 +271,10 @@ class MacrosTest extends AnyFlatSpec with BeforeAndAfter {
     adtMulOp.operand2 `equals` unverMulOp.operands(1) should be(true)
     adtMulOp.result1 `equals` unverMulOp.results(0) should be(true)
     adtMulOp.result2 `equals` unverMulOp.results(1) should be(true)
-    adtMulOp.randProp1 `equals` unverMulOp.dictionaryProperties(
+    adtMulOp.randProp1 `equals` unverMulOp.properties(
       "randProp1"
     ) should be(true)
-    adtMulOp.randProp2 `equals` unverMulOp.dictionaryProperties(
+    adtMulOp.randProp2 `equals` unverMulOp.properties(
       "randProp2"
     ) should be(true)
     adtMulOp.reg1 `equals` unverMulOp.regions(0) should be(true)
@@ -328,7 +328,7 @@ class MacrosTest extends AnyFlatSpec with BeforeAndAfter {
             Result(IntegerType(IntData(25), Unsigned))
           ) =>
     }
-    unverMulSinVarOp.dictionaryProperties("randProp") should matchPattern {
+    unverMulSinVarOp.properties("randProp") should matchPattern {
       case StringData("what") =>
     }
   }

--- a/core/src/main/scala-3/Parser.scala
+++ b/core/src/main/scala-3/Parser.scala
@@ -727,9 +727,9 @@ class Parser(val context: MLContext, val args: Args = Args())
         x(
           operands = useAndRefValueSeqs._1,
           successors = useAndRefBlockSeqs._1,
-          dictionaryProperties = properties,
+          properties = properties,
           results_types = ListType.from(resultsTypes),
-          dictionaryAttributes = attributes,
+          attributes = attributes,
           regions = ListType.from(regions)
         )
 
@@ -739,9 +739,9 @@ class Parser(val context: MLContext, val args: Args = Args())
             name = opName,
             operands = useAndRefValueSeqs._1,
             successors = useAndRefBlockSeqs._1,
-            dictionaryProperties = properties,
+            properties = properties,
             results_types = ListType.from(resultsTypes),
-            dictionaryAttributes = attributes,
+            attributes = attributes,
             regions = ListType.from(regions)
           )
         else
@@ -792,7 +792,7 @@ class Parser(val context: MLContext, val args: Args = Args())
   def GenericOperation[$: P](resNames: Seq[String]) = P(
     (StringLiteral ~/ "(" ~ ValueUseList.orElse(Seq()) ~ ")"
       ~/ SuccessorList.orElse(Seq())
-      ~/ DictionaryProperties.orElse(DictType.empty)
+      ~/ properties.orElse(DictType.empty)
       ~/ RegionList.orElse(Seq())
       ~/ (DictionaryAttribute).orElse(DictType.empty) ~/ ":" ~/ FunctionType)
       .mapTry(
@@ -950,7 +950,7 @@ class Parser(val context: MLContext, val args: Args = Args())
     * @return
     *   A properties dictionary parser.
     */
-  def DictionaryProperties[$: P] = P(
+  def properties[$: P] = P(
     "<" ~ DictionaryAttribute ~ ">"
   )
 
@@ -972,7 +972,7 @@ class Parser(val context: MLContext, val args: Args = Args())
     *   present.
     */
   inline def OptionalProperties[$: P]() =
-    (DictionaryProperties).orElse(DictType.empty)
+    (properties).orElse(DictType.empty)
 
   /** Parses an optional attributes dictionary from the input.
     *

--- a/core/src/main/scala-3/Printer.scala
+++ b/core/src/main/scala-3/Printer.scala
@@ -166,18 +166,18 @@ case class Printer(
           .mkString(", ") + "]"
       else ""
 
-    val dictionaryProperties: String =
-      if (op.dictionaryProperties.size > 0)
+    val properties: String =
+      if (op.properties.size > 0)
         " <{" + (for {
-          (key, value) <- op.dictionaryProperties
+          (key, value) <- op.properties
         } yield s"$key = ${value.custom_print}")
           .mkString(", ") + "}>"
       else ""
 
-    val dictionaryAttributes: String =
-      if (op.dictionaryAttributes.size > 0)
+    val attributes: String =
+      if (op.attributes.size > 0)
         " {" + (for {
-          (key, value) <- op.dictionaryAttributes
+          (key, value) <- op.attributes
         } yield s"$key = ${value.custom_print}")
           .mkString(", ") + "}"
       else ""
@@ -187,7 +187,7 @@ case class Printer(
         ") -> (" +
         resultsTypes.mkString(", ") + ")"
 
-    return s"${"\""}${op.name}${"\""}($operationOperands)$operationSuccessors$dictionaryProperties$operationRegions$dictionaryAttributes : $functionType"
+    return s"${"\""}${op.name}${"\""}($operationOperands)$operationSuccessors$properties$operationRegions$attributes : $functionType"
   }
 
   def printOperation(op: Operation, indentLevel: Int = 0): String = {

--- a/core/src/main/scala-3/builtin/Builtin.scala
+++ b/core/src/main/scala-3/builtin/Builtin.scala
@@ -467,9 +467,9 @@ case class ModuleOp(
     override val successors: ListType[Block] = ListType(),
     results_types: ListType[Attribute] = ListType(),
     override val regions: ListType[Region] = ListType(),
-    override val dictionaryProperties: DictType[String, Attribute] =
+    override val properties: DictType[String, Attribute] =
       DictType.empty[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute] =
+    override val attributes: DictType[String, Attribute] =
       DictType.empty[String, Attribute]
 ) extends BaseOperation(
       name = "builtin.module",
@@ -477,8 +477,8 @@ case class ModuleOp(
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_print(

--- a/core/src/main/scala-3/scairdl/IRElements.scala
+++ b/core/src/main/scala-3/scairdl/IRElements.scala
@@ -283,8 +283,8 @@ case class OperationDef(
 
   def operand_segment_sizes_helper: String =
     s"""def operandSegmentSizes: Seq[Int] =
-    if (!dictionaryProperties.contains("operandSegmentSizes")) then throw new Exception("Expected operandSegmentSizes property")
-    val operandSegmentSizes_attr = dictionaryProperties("operandSegmentSizes") match {
+    if (!properties.contains("operandSegmentSizes")) then throw new Exception("Expected operandSegmentSizes property")
+    val operandSegmentSizes_attr = properties("operandSegmentSizes") match {
       case right: DenseArrayAttr => right
       case _ => throw new Exception("Expected operandSegmentSizes to be a DenseArrayAttr")
     }
@@ -314,8 +314,8 @@ case class OperationDef(
 
   def result_segment_sizes_helper: String =
     s"""def resultSegmentSizes: Seq[Int] =
-    if (!dictionaryProperties.contains("resultSegmentSizes")) then throw new Exception("Expected resultSegmentSizes property")
-    val resultSegmentSizes_attr = dictionaryProperties("resultSegmentSizes") match {
+    if (!properties.contains("resultSegmentSizes")) then throw new Exception("Expected resultSegmentSizes property")
+    val resultSegmentSizes_attr = properties("resultSegmentSizes") match {
       case right: DenseArrayAttr => right
       case _ => throw new Exception("Expected resultSegmentSizes to be a DenseArrayAttr")
     }
@@ -645,11 +645,11 @@ case class OperationDef(
       regions_accessors ++
       successors_accessors ++
       (for pdef <- OpProperty
-      yield s"  def ${pdef.id}: Attribute = dictionaryProperties(\"${pdef.id}\")\n" +
-        s"  def ${pdef.id}_=(new_attribute: Attribute): Unit = {dictionaryProperties(\"${pdef.id}\") = new_attribute}\n") ++
+      yield s"  def ${pdef.id}: Attribute = properties(\"${pdef.id}\")\n" +
+        s"  def ${pdef.id}_=(new_attribute: Attribute): Unit = {properties(\"${pdef.id}\") = new_attribute}\n") ++
       (for adef <- OpAttribute
-      yield s"  def ${adef.id}: Attribute = dictionaryAttributes(\"${adef.id}\")\n" +
-        s"  def ${adef.id}_=(new_attribute: Attribute): Unit = {dictionaryAttributes(\"${adef.id}\") = new_attribute}\n"))
+      yield s"  def ${adef.id}: Attribute = attributes(\"${adef.id}\")\n" +
+        s"  def ${adef.id}_=(new_attribute: Attribute): Unit = {attributes(\"${adef.id}\") = new_attribute}\n"))
       .mkString("\n")
 
   }
@@ -759,11 +759,11 @@ case class $className(
     override val successors: ListType[Block] = ListType(),
     results_types: ListType[Attribute] = ListType(),
     override val regions: ListType[Region] = ListType(),
-    override val dictionaryProperties: DictType[String, Attribute] =
+    override val properties: DictType[String, Attribute] =
       DictType.empty[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute] =
+    override val attributes: DictType[String, Attribute] =
       DictType.empty[String, Attribute]
-) extends RegisteredOperation(name = "$name", operands, successors, results_types, regions, dictionaryProperties, dictionaryAttributes) {
+) extends RegisteredOperation(name = "$name", operands, successors, results_types, regions, properties, attributes) {
 
 
 ${helpers(indent + 1)}

--- a/core/test/src/scala-3/TraitTest.scala
+++ b/core/test/src/scala-3/TraitTest.scala
@@ -17,9 +17,9 @@ case class FillerOp(
     override val successors: ListType[Block] = ListType(),
     results_types: ListType[Attribute] = ListType(),
     override val regions: ListType[Region] = ListType(),
-    override val dictionaryProperties: DictType[String, Attribute] =
+    override val properties: DictType[String, Attribute] =
       DictType.empty[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute] =
+    override val attributes: DictType[String, Attribute] =
       DictType.empty[String, Attribute]
 ) extends BaseOperation(
       name = "filler",
@@ -27,8 +27,8 @@ case class FillerOp(
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {}
 
 object TerminatorOp extends OperationCompanion {
@@ -40,9 +40,9 @@ case class TerminatorOp(
     override val successors: ListType[Block] = ListType(),
     results_types: ListType[Attribute] = ListType(),
     override val regions: ListType[Region] = ListType(),
-    override val dictionaryProperties: DictType[String, Attribute] =
+    override val properties: DictType[String, Attribute] =
       DictType.empty[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute] =
+    override val attributes: DictType[String, Attribute] =
       DictType.empty[String, Attribute]
 ) extends BaseOperation(
       name = "terminator",
@@ -50,8 +50,8 @@ case class TerminatorOp(
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     )
     with IsTerminator {}
 
@@ -64,9 +64,9 @@ case class NoTerminatorOp(
     override val successors: ListType[Block] = ListType(),
     results_types: ListType[Attribute] = ListType(),
     override val regions: ListType[Region] = ListType(),
-    override val dictionaryProperties: DictType[String, Attribute] =
+    override val properties: DictType[String, Attribute] =
       DictType.empty[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute] =
+    override val attributes: DictType[String, Attribute] =
       DictType.empty[String, Attribute]
 ) extends BaseOperation(
       name = "noterminator",
@@ -74,8 +74,8 @@ case class NoTerminatorOp(
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     )
     with NoTerminator {}
 

--- a/core/test/src/scala-3/ir/Block.scala
+++ b/core/test/src/scala-3/ir/Block.scala
@@ -15,9 +15,9 @@ case class TestOp(
     override val successors: ListType[Block] = ListType(),
     results_types: ListType[Attribute] = ListType(),
     override val regions: ListType[Region] = ListType(),
-    override val dictionaryProperties: DictType[String, Attribute] =
+    override val properties: DictType[String, Attribute] =
       DictType.empty[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute] =
+    override val attributes: DictType[String, Attribute] =
       DictType.empty[String, Attribute]
 ) extends BaseOperation(
       name = "test.op",
@@ -25,8 +25,8 @@ case class TestOp(
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     )
 
 class BlockTest extends AnyFlatSpec with BeforeAndAfter {

--- a/dialects/src/main/scala-3/affine/Affine.scala
+++ b/dialects/src/main/scala-3/affine/Affine.scala
@@ -27,7 +27,7 @@ case class Apply(
     mapOperands: Seq[Operand[IndexType.type]],
     res: Result[IndexType.type],
     map: AffineMapAttr
-) extends MLIRName["affine.apply"]
+) extends DerivedOperation["affine.apply", Apply]
     derives DerivedOperationCompanion
 
 /*≡==---=≡≡≡≡=---=≡≡*\
@@ -43,7 +43,7 @@ case class For(
     upperBoundMap: AffineMapAttr,
     step: IntegerAttr,
     body: Region
-) extends MLIRName["affine.for"]
+) extends DerivedOperation["affine.for", For]
     derives DerivedOperationCompanion
 
 /*≡==---==≡≡≡≡≡==---=≡≡*\
@@ -61,7 +61,7 @@ case class Parallel(
     upperBoundsGroups: DenseIntOrFPElementsAttr,
     res: Seq[Result[Attribute]],
     body: Region
-) extends MLIRName["affine.parallel"]
+) extends DerivedOperation["affine.parallel", Parallel]
     derives DerivedOperationCompanion
 
 /*≡==--=≡≡≡=--=≡≡*\
@@ -74,7 +74,7 @@ case class If(
     condition: AffineSetAttr,
     then_region: Region,
     else_region: Region
-) extends MLIRName["affine.if"]
+) extends DerivedOperation["affine.if", If]
     derives DerivedOperationCompanion
 
 /*≡==--=≡≡≡≡=--=≡≡*\
@@ -86,7 +86,7 @@ case class Store(
     memref: Operand[MemrefType],
     indices: Seq[Operand[IndexType.type]],
     map: AffineMapAttr
-) extends MLIRName["affine.store"]
+) extends DerivedOperation["affine.store", Store]
     derives DerivedOperationCompanion
 
 /*≡==---=≡≡≡=---=≡≡*\
@@ -98,7 +98,7 @@ case class Load(
     indices: Seq[Operand[IndexType.type]],
     result: Result[Attribute],
     map: AffineMapAttr
-) extends MLIRName["affine.load"]
+) extends DerivedOperation["affine.load", Load]
     derives DerivedOperationCompanion
 
 /*≡==--=≡≡≡≡=--=≡≡*\
@@ -109,7 +109,7 @@ case class Min(
     arguments: Seq[Operand[IndexType.type]],
     result: Result[IndexType.type],
     map: AffineMapAttr
-) extends MLIRName["affine.min"]
+) extends DerivedOperation["affine.min", Min]
     derives DerivedOperationCompanion
 
 /*≡==--=≡≡≡≡=--=≡≡*\
@@ -118,7 +118,7 @@ case class Min(
 
 case class Yield(
     arguments: Seq[Operand[Attribute]]
-) extends MLIRName["affine.yield"]
+) extends DerivedOperation["affine.yield", Yield]
     derives DerivedOperationCompanion
 
 val AffineDialect = summonDialect[

--- a/dialects/src/main/scala-3/arith/Arith.scala
+++ b/dialects/src/main/scala-3/arith/Arith.scala
@@ -121,7 +121,7 @@ case class Addf(
     result: Result[FloatType],
     fastmath: FastMathFlagsAttr
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends MLIRName["arith.addf"]
+) extends DerivedOperation["arith.addf", Addf]
     derives DerivedOperationCompanion
 
 case class Mulf(
@@ -130,7 +130,7 @@ case class Mulf(
     result: Result[FloatType],
     fastmath: FastMathFlagsAttr
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends MLIRName["arith.mulf"]
+) extends DerivedOperation["arith.mulf", Mulf]
     derives DerivedOperationCompanion
 
 // I'm not sure about the flag here
@@ -140,7 +140,7 @@ case class Divf(
     result: Result[FloatType],
     fastmath: FastMathFlagsAttr
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends MLIRName["arith.divf"]
+) extends DerivedOperation["arith.divf", Divf]
     derives DerivedOperationCompanion
 
 // TODO Apparently there's a new overflow flag here, overlooking for now.
@@ -149,7 +149,7 @@ case class Addi(
     rhs: Operand[AnyIntegerType],
     result: Result[AnyIntegerType]
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends MLIRName["arith.addi"]
+) extends DerivedOperation["arith.addi", Addi]
     derives DerivedOperationCompanion
 
 case class Subi(
@@ -157,7 +157,7 @@ case class Subi(
     rhs: Operand[AnyIntegerType],
     result: Result[AnyIntegerType]
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends MLIRName["arith.subi"]
+) extends DerivedOperation["arith.subi", Subi]
     derives DerivedOperationCompanion
 
 case class Muli(
@@ -165,7 +165,7 @@ case class Muli(
     rhs: Operand[AnyIntegerType],
     result: Result[AnyIntegerType]
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends MLIRName["arith.muli"]
+) extends DerivedOperation["arith.muli", Muli]
     derives DerivedOperationCompanion
 
 case class Divui(
@@ -173,7 +173,7 @@ case class Divui(
     rhs: Operand[AnyIntegerType],
     result: Result[AnyIntegerType]
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends MLIRName["arith.divui"]
+) extends DerivedOperation["arith.divui", Divui]
     derives DerivedOperationCompanion
 
 case class Divsi(
@@ -181,7 +181,7 @@ case class Divsi(
     rhs: Operand[AnyIntegerType],
     result: Result[AnyIntegerType]
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends MLIRName["arith.divsi"]
+) extends DerivedOperation["arith.divsi", Divsi]
     derives DerivedOperationCompanion
 
 case class Remui(
@@ -189,7 +189,7 @@ case class Remui(
     rhs: Operand[AnyIntegerType],
     result: Result[AnyIntegerType]
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends MLIRName["arith.remui"]
+) extends DerivedOperation["arith.remui", Remui]
     derives DerivedOperationCompanion
 
 case class Remsi(
@@ -197,7 +197,7 @@ case class Remsi(
     rhs: Operand[AnyIntegerType],
     result: Result[AnyIntegerType]
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends MLIRName["arith.remsi"]
+) extends DerivedOperation["arith.remsi", Remsi]
     derives DerivedOperationCompanion
 
 case class Cmpi(
@@ -206,7 +206,7 @@ case class Cmpi(
     result: Result[I1],
     predicate: IntegerPredicate
     // assembly_format: "$predicate `,` $lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends MLIRName["arith.cmpi"]
+) extends DerivedOperation["arith.cmpi", Cmpi]
     derives DerivedOperationCompanion
 
 case class Andi(
@@ -214,7 +214,7 @@ case class Andi(
     rhs: Operand[AnyIntegerType],
     result: Result[I1]
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends MLIRName["arith.andi"]
+) extends DerivedOperation["arith.andi", Andi]
     derives DerivedOperationCompanion
 
 case class Ori(
@@ -222,21 +222,21 @@ case class Ori(
     rhs: Operand[AnyIntegerType],
     result: Result[I1]
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends MLIRName["arith.ori"]
+) extends DerivedOperation["arith.ori", Ori]
     derives DerivedOperationCompanion
 
 case class Sitofp(
     in: Operand[AnyIntegerType],
     out: Result[FloatType]
     // assembly_format: "$in `:` type($in) `to` type($out)"
-) extends MLIRName["arith.sitofp"]
+) extends DerivedOperation["arith.sitofp", Sitofp]
     derives DerivedOperationCompanion
 
 case class Index_Cast(
     in: Operand[AnyIntegerType],
     result: Result[AnyIntegerType]
     // assembly_format: "$in `:` type($in) `to` type($out)"
-) extends MLIRName["arith.index_cast"]
+) extends DerivedOperation["arith.index_cast", Index_Cast]
     derives DerivedOperationCompanion
 
 val ArithDialect =

--- a/dialects/src/main/scala-3/cmath/CMath.scala
+++ b/dialects/src/main/scala-3/cmath/CMath.scala
@@ -18,14 +18,14 @@ case class Complex(
 case class Norm(
     in: Operand[Complex],
     res: Result[FloatType]
-) extends MLIRName["cmath.norm"]
+) extends DerivedOperation["cmath.norm", Norm]
     derives DerivedOperationCompanion
 
 case class Mul(
     lhs: Operand[Complex],
     rhs: Operand[Complex],
     res: Result[Complex]
-) extends MLIRName["cmath.mul"]
+) extends DerivedOperation["cmath.mul", Mul]
     derives DerivedOperationCompanion
 
 val CMathDialect = summonDialect[Tuple1[Complex], (Norm, Mul)](Seq())

--- a/dialects/src/main/scala-3/func/Func.scala
+++ b/dialects/src/main/scala-3/func/Func.scala
@@ -9,7 +9,7 @@ case class Call(
     callee: SymbolRefAttr,
     _operands: Seq[Operand[Attribute]],
     _results: Seq[Result[Attribute]]
-) extends MLIRName["func.call"]
+) extends DerivedOperation["func.call", Call]
     derives DerivedOperationCompanion
 
 case class Func(
@@ -18,12 +18,12 @@ case class Func(
     // TODO: This needs optional
     // sym_visibility: StringData,
     body: Region
-) extends MLIRName["func.func"]
+) extends DerivedOperation["func.func", Func]
     derives DerivedOperationCompanion
 
 case class Return(
     _operands: Seq[Operand[Attribute]]
-) extends MLIRName["func.return"]
+) extends DerivedOperation["func.return", Return]
     derives DerivedOperationCompanion
 
 val FuncDialect = summonDialect[EmptyTuple, (Call, Func, Return)](Seq())

--- a/dialects/src/main/scala-3/lingodb/DBOps.scala
+++ b/dialects/src/main/scala-3/lingodb/DBOps.scala
@@ -300,16 +300,16 @@ case class DB_ConstantOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "db.constant",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
@@ -317,7 +317,7 @@ case class DB_ConstantOp(
     successors.length,
     results.length,
     regions.length,
-    dictionaryProperties.size
+    properties.size
   ) match {
     case (0, 0, 1, 0, 0) =>
     case _ =>
@@ -328,7 +328,7 @@ case class DB_ConstantOp(
 
   override def custom_print(printer: Printer): String = {
     val value =
-      dictionaryAttributes.get("value").map(_.custom_print).getOrElse("")
+      attributes.get("value").map(_.custom_print).getOrElse("")
     val resultType = results.head.typ
     s"$name($value) : ${resultType.custom_print}"
   }
@@ -374,16 +374,16 @@ case class DB_CmpOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "db.compare",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
@@ -391,7 +391,7 @@ case class DB_CmpOp(
     successors.length,
     results.length,
     regions.length,
-    dictionaryProperties.size
+    properties.size
   ) match {
     case (2, 0, 0, 0, 0) =>
       (operands(0).typ == operands(1).typ) match {
@@ -414,7 +414,7 @@ case class DB_CmpOp(
       s"${printer.printValue(operands(1))} : ${operands(1).typ.custom_print}"
     val resultType = results.head.typ.custom_print
     val predicate =
-      dictionaryAttributes.get("predicate").map(_.custom_print).getOrElse("")
+      attributes.get("predicate").map(_.custom_print).getOrElse("")
     s"$name $predicate $operand1, $operand2 : $resultType"
   }
 
@@ -515,16 +515,16 @@ case class DB_MulOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "db.mul",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
@@ -532,7 +532,7 @@ case class DB_MulOp(
     successors.length,
     results.length,
     regions.length,
-    dictionaryProperties.size
+    properties.size
   ) match {
     case (2, 0, 1, 0, 0) =>
       (operands(0).typ == operands(1).typ) match {
@@ -557,7 +557,7 @@ case class DB_MulOp(
       s"${printer.printValue(operands(1))} : ${operands(1).typ.custom_print}"
     val resultType = results.head.typ.custom_print
     val predicate =
-      dictionaryAttributes.get("predicate").map(_.custom_print).getOrElse("")
+      attributes.get("predicate").map(_.custom_print).getOrElse("")
     s"$name $operand1, $operand2 : $resultType"
   }
 
@@ -661,16 +661,16 @@ case class DB_DivOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "db.div",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
@@ -678,7 +678,7 @@ case class DB_DivOp(
     successors.length,
     results.length,
     regions.length,
-    dictionaryProperties.size
+    properties.size
   ) match {
     case (2, 0, 1, 0, 0) =>
       (operands(0).typ == operands(1).typ) match {
@@ -743,16 +743,16 @@ case class DB_AddOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "db.add",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
@@ -760,7 +760,7 @@ case class DB_AddOp(
     successors.length,
     results.length,
     regions.length,
-    dictionaryProperties.size
+    properties.size
   ) match {
     case (2, 0, 1, 0, 0) =>
       (operands(0).typ == operands(1).typ) match {
@@ -827,16 +827,16 @@ case class DB_SubOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "db.sub",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
@@ -844,7 +844,7 @@ case class DB_SubOp(
     successors.length,
     results.length,
     regions.length,
-    dictionaryProperties.size
+    properties.size
   ) match {
     case (2, 0, 1, 0, 0) =>
       (operands(0).typ == operands(1).typ) match {
@@ -908,16 +908,16 @@ case class CastOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "db.cast",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
@@ -925,7 +925,7 @@ case class CastOp(
     successors.length,
     results.length,
     regions.length,
-    dictionaryProperties.size
+    properties.size
   ) match {
     case (1, 0, 1, 0, 0) =>
     case _ =>

--- a/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
+++ b/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
@@ -188,16 +188,16 @@ case class BaseTableOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "relalg.basetable",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
@@ -214,7 +214,7 @@ case class BaseTableOp(
             "BaseTableOp Operation must contain only 1 result."
           )
       }
-      dictionaryAttributes.get("table_identifier") match {
+      attributes.get("table_identifier") match {
         case Some(x) =>
           x match {
             case _: StringData =>
@@ -271,16 +271,16 @@ case class SelectionOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "relalg.selection",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
@@ -350,16 +350,16 @@ case class MapOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "relalg.map",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
@@ -384,7 +384,7 @@ case class MapOp(
           )
       }
 
-      dictionaryAttributes.get("computed_cols") match {
+      attributes.get("computed_cols") match {
         case Some(x) =>
           x match {
             case _: ArrayAttribute[_] =>
@@ -452,16 +452,16 @@ case class AggregationOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "relalg.aggregation",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
@@ -486,7 +486,7 @@ case class AggregationOp(
           )
       }
 
-      dictionaryAttributes.get("computed_cols") match {
+      attributes.get("computed_cols") match {
         case Some(x) =>
           x match {
             case _: ArrayAttribute[_] =>
@@ -501,7 +501,7 @@ case class AggregationOp(
           )
       }
 
-      dictionaryAttributes.get("group_by_cols") match {
+      attributes.get("group_by_cols") match {
         case Some(x) =>
           x match {
             case _: ArrayAttribute[_] =>
@@ -554,16 +554,16 @@ case class CountRowsOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "relalg.count",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
@@ -635,16 +635,16 @@ case class AggrFuncOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "relalg.aggrfn",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
@@ -661,7 +661,7 @@ case class AggrFuncOp(
             "AggrFuncOp Operation must contain 1 operand of type TupleStream."
           )
       }
-      dictionaryAttributes.get("fn") match {
+      attributes.get("fn") match {
         case Some(x) =>
           x match {
             case _: RelAlg_AggrFunc_Case =>
@@ -676,7 +676,7 @@ case class AggrFuncOp(
           )
       }
 
-      dictionaryAttributes.get("attr") match {
+      attributes.get("attr") match {
         case Some(x) =>
           x match {
             case _: ColumnRefAttr =>
@@ -739,16 +739,16 @@ case class SortOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "relalg.sort",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
@@ -772,7 +772,7 @@ case class SortOp(
             "SortOp Operation must contain 1 operand of type TupleStream."
           )
       }
-      dictionaryAttributes.get("sortspecs") match {
+      attributes.get("sortspecs") match {
         case Some(x) =>
           x match {
             case _: ArrayAttribute[_] =>
@@ -841,16 +841,16 @@ case class MaterializeOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "relalg.materialize",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
@@ -875,7 +875,7 @@ case class MaterializeOp(
           )
       }
 
-      dictionaryAttributes.get("cols") match {
+      attributes.get("cols") match {
         case Some(x) =>
           x match {
             case _: ArrayAttribute[_] =>
@@ -890,7 +890,7 @@ case class MaterializeOp(
           )
       }
 
-      dictionaryAttributes.get("columns") match {
+      attributes.get("columns") match {
         case Some(x) =>
           x match {
             case _: ArrayAttribute[_] =>

--- a/dialects/src/main/scala-3/lingodb/SubOperatorOps.scala
+++ b/dialects/src/main/scala-3/lingodb/SubOperatorOps.scala
@@ -112,16 +112,16 @@ case class SetResultOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "subop.set_result",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
@@ -129,10 +129,10 @@ case class SetResultOp(
     successors.length,
     results.length,
     regions.length,
-    dictionaryProperties.size
+    properties.size
   ) match {
     case (1, 0, 0, 0, 0) =>
-      dictionaryAttributes.get("result_id") match {
+      attributes.get("result_id") match {
         case Some(x) =>
           x match {
             case _: IntegerAttr =>

--- a/dialects/src/main/scala-3/lingodb/TupleStream.scala
+++ b/dialects/src/main/scala-3/lingodb/TupleStream.scala
@@ -167,23 +167,23 @@ case class ReturnOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "tuples.return",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
     operands.length,
     successors.length,
     regions.length,
-    dictionaryProperties.size
+    properties.size
   ) match {
     case (0, 0, 0, 0) =>
     case _ =>
@@ -232,16 +232,16 @@ case class GetColumnOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "tuples.getcol",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
@@ -249,7 +249,7 @@ case class GetColumnOp(
     successors.length,
     results.length,
     regions.length,
-    dictionaryProperties.size
+    properties.size
   ) match {
     case (1, 0, 1, 0, 0) =>
       operands(0).typ match {
@@ -259,7 +259,7 @@ case class GetColumnOp(
             "GetColumnOp Operation must contain an operand of type TupleStreamTuple."
           )
       }
-      dictionaryAttributes.get("attr") match {
+      attributes.get("attr") match {
         case Some(x) =>
           x match {
             case _: ColumnRefAttr =>

--- a/dialects/src/main/scala-3/llvm/LLVM.scala
+++ b/dialects/src/main/scala-3/llvm/LLVM.scala
@@ -16,7 +16,7 @@ case class Ptr()
 case class Load(
     ptr: Operand[Ptr],
     result: Result[Attribute]
-) extends MLIRName["llvm.load"]
+) extends DerivedOperation["llvm.load", Load]
     derives DerivedOperationCompanion
 
 case class GetElementPtr(
@@ -25,7 +25,7 @@ case class GetElementPtr(
     res: Result[Ptr],
     rawConstantIndices: DenseArrayAttr,
     elem_type: Attribute
-) extends MLIRName["llvm.getelementptr"]
+) extends DerivedOperation["llvm.getelementptr", GetElementPtr]
     derives DerivedOperationCompanion
 
 val LLVMDialect = summonDialect[Tuple1[Ptr], (Load, GetElementPtr)](Seq())

--- a/dialects/src/main/scala-3/math/Math.scala
+++ b/dialects/src/main/scala-3/math/Math.scala
@@ -40,16 +40,16 @@ case class AbsfOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "math.absf",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
@@ -57,7 +57,7 @@ case class AbsfOp(
     results.length,
     successors.length,
     regions.length,
-    dictionaryProperties.size
+    properties.size
   ) match {
     case (1, 1, 0, 0, 0) =>
     case _ =>
@@ -103,16 +103,16 @@ case class FPowIOp(
     override val successors: ListType[Block],
     results_types: ListType[Attribute],
     override val regions: ListType[Region],
-    override val dictionaryProperties: DictType[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute]
+    override val properties: DictType[String, Attribute],
+    override val attributes: DictType[String, Attribute]
 ) extends BaseOperation(
       name = "math.fpowi",
       operands,
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     ) {
 
   override def custom_verify(): Unit = (
@@ -120,7 +120,7 @@ case class FPowIOp(
     results.length,
     successors.length,
     regions.length,
-    dictionaryProperties.size
+    properties.size
   ) match {
     case (2, 1, 0, 0, 0) =>
     case _ =>

--- a/dialects/src/main/scala-3/memref/Memref.scala
+++ b/dialects/src/main/scala-3/memref/Memref.scala
@@ -10,26 +10,26 @@ case class Alloc(
     symbolOperands: Seq[Operand[IndexType.type]],
     memref: Result[MemrefType],
     alignment: IntegerAttr
-) extends MLIRName["memref.alloc"]
+) extends DerivedOperation["memref.alloc", Alloc]
     derives DerivedOperationCompanion
 
 case class Dealloc(
     memref: Operand[MemrefType]
-) extends MLIRName["memref.dealloc"]
+) extends DerivedOperation["memref.dealloc", Dealloc]
     derives DerivedOperationCompanion
 
 case class Load(
     memref: Operand[MemrefType],
     indices: Seq[Operand[IndexType.type]],
     result: Result[Attribute]
-) extends MLIRName["memref.load"]
+) extends DerivedOperation["memref.load", Load]
     derives DerivedOperationCompanion
 
 case class Store(
     value: Operand[Attribute],
     memref: Operand[MemrefType],
     indices: Seq[Operand[IndexType.type]]
-) extends MLIRName["memref.store"]
+) extends DerivedOperation["memref.store", Store]
     derives DerivedOperationCompanion
 
 val MemrefDialect =

--- a/dialects/src/main/scala-3/test/Test.scala
+++ b/dialects/src/main/scala-3/test/Test.scala
@@ -7,9 +7,9 @@ case class TestOp(
     override val successors: ListType[Block] = ListType(),
     results_types: ListType[Attribute] = ListType(),
     override val regions: ListType[Region] = ListType(),
-    override val dictionaryProperties: DictType[String, Attribute] =
+    override val properties: DictType[String, Attribute] =
       DictType.empty[String, Attribute],
-    override val dictionaryAttributes: DictType[String, Attribute] =
+    override val attributes: DictType[String, Attribute] =
       DictType.empty[String, Attribute]
 ) extends BaseOperation(
       name = "test.op",
@@ -17,8 +17,8 @@ case class TestOp(
       successors,
       results_types,
       regions,
-      dictionaryProperties,
-      dictionaryAttributes
+      properties,
+      attributes
     )
 
 object TestOp extends OperationCompanion {

--- a/transformations/src/main/scala-3/CMathDummyTransformation.scala
+++ b/transformations/src/main/scala-3/CMathDummyTransformation.scala
@@ -15,9 +15,9 @@ object AddDummyAttributeToDict extends RewritePattern {
   ): Unit = {
     op match {
       case x: UnregisteredOperation =>
-        x.dictionaryAttributes += ("dummy" -> StringData("UnregDumDum"))
+        x.attributes += ("dummy" -> StringData("UnregDumDum"))
       case d =>
-        d.dictionaryAttributes += ("dummy" -> StringData("dumdum"))
+        d.attributes += ("dummy" -> StringData("dumdum"))
     }
     rewriter.has_done_action = true
   }
@@ -45,7 +45,7 @@ object TestInsertingDummyOperation extends RewritePattern {
         )
         rewriter.erase_matched_op()
       case false =>
-        op.dictionaryAttributes += ("replaced" -> StringData("false"))
+        op.attributes += ("replaced" -> StringData("false"))
     }
 
     rewriter.has_done_action = true
@@ -88,7 +88,7 @@ object TestReplacingDummyOperation extends RewritePattern {
           Some(op3.results.toSeq)
         )
       case false =>
-        op.dictionaryAttributes += ("replaced" -> StringData("false"))
+        op.attributes += ("replaced" -> StringData("false"))
     }
 
     rewriter.has_done_action = true


### PR DESCRIPTION
Now the ADTs *are* operations!

Disclaimers:
- The API is a lie so far as discussed. Sure, you'll get a mutable list of operands, but this does no promise of actually mutating the op - in practice, does not on ADTs.
- The ADT-side look is not so gorgeous at this point (`extends DerivedOperation derives DerivedOperationCompanion`)

But, one PR at a time!

Other changes:
- `dictionaryAttributes` -> `attributes`
- `dictionaryProperties` -> `properties`
- More general Operation methods raised to top `Operation` as `final def`s
- `container_block` & `attributes` are just mutable state on *all* ops; should buy some time before questioning the whole references-to-parents side of things, if it still ends up necessary.