### PR TITLE
More idiomatic Either usage

### DIFF
--- a/clair/src/main/scala-3/Macros.scala
+++ b/clair/src/main/scala-3/Macros.scala
@@ -698,16 +698,16 @@ trait DerivedOperationCompanion[T] extends OperationCompanion {
       )
     }
 
-    override def verify(): Either[Operation, String] = {
+    override def verify(): Either[String, Operation] = {
       Try(companion.verify(this)) match {
         case Success(op) =>
           op match {
             case adtOp: DerivedOperation[_, T] =>
               adtOp.verify()
             case _ =>
-              Right("Internal Error: Operation is not a DerivedOperation")
+              Left("Internal Error: Operation is not a DerivedOperation")
           }
-        case Failure(e) => Right(e.toString())
+        case Failure(e) => Left(e.toString())
       }
     }
 

--- a/clair/test/src/scala-3/MacrosTest.scala
+++ b/clair/test/src/scala-3/MacrosTest.scala
@@ -413,7 +413,7 @@ class MacrosTest extends AnyFlatSpec with BeforeAndAfter {
 
     val verified = op.verify()
     verified should matchPattern {
-      case Left(
+      case Right(
             RegionOp(
               Seq(
                 Region(
@@ -434,7 +434,7 @@ class MacrosTest extends AnyFlatSpec with BeforeAndAfter {
 
     val verified = unverOp.verify()
     verified should matchPattern {
-      case Right("java.lang.Exception: Expected 2 operands, got 0.") =>
+      case Left("java.lang.Exception: Expected 2 operands, got 0.") =>
     }
   }
 

--- a/core/src/main/scala-3/Parser.scala
+++ b/core/src/main/scala-3/Parser.scala
@@ -184,8 +184,8 @@ object Parser {
             throw new Exception(
               s"%$name use with type ${typ} but defined with type ${valueMap(name).typ}"
             )
-          else Left(valueMap(name))
-        else Right((name, typ))
+          else Right(valueMap(name))
+        else Left((name, typ))
       )
     }
 
@@ -283,8 +283,8 @@ object Parser {
         successorList: Seq[String]
     ) =
       successorList.partitionMap(name =>
-        if blockMap.contains(name) then Left(blockMap(name))
-        else Right(name)
+        if blockMap.contains(name) then Right(blockMap(name))
+        else Left(name)
       )
 
     // check block waitlist once you exit the local scope of a region,
@@ -709,8 +709,8 @@ class Parser(val context: MLContext, val args: Args = Args())
     val op: Operation = ctx.getOperation(opName) match {
       case Some(x) =>
         x(
-          operands = useAndRefValueSeqs._1,
-          successors = useAndRefBlockSeqs._1,
+          operands = useAndRefValueSeqs._2,
+          successors = useAndRefBlockSeqs._2,
           properties = properties,
           results = resultsTypes.map(Result(_)),
           attributes = DictType.from(attributes),
@@ -721,8 +721,8 @@ class Parser(val context: MLContext, val args: Args = Args())
         if args.allow_unregistered then
           new UnregisteredOperation(
             name = opName,
-            operands = useAndRefValueSeqs._1,
-            successors = useAndRefBlockSeqs._1,
+            operands = useAndRefValueSeqs._2,
+            successors = useAndRefBlockSeqs._2,
             properties = properties,
             results = resultsTypes.map(Result(_)),
             attributes = DictType.from(attributes),
@@ -733,11 +733,11 @@ class Parser(val context: MLContext, val args: Args = Args())
             s"Operation ${opName} is not registered. If this is intended, use `--allow-unregistered-dialect`"
           )
     }
-    if (useAndRefValueSeqs._2.length > 0) {
-      currentScope.valueWaitlist += op -> useAndRefValueSeqs._2
+    if (useAndRefValueSeqs._1.length > 0) {
+      currentScope.valueWaitlist += op -> useAndRefValueSeqs._1
     }
-    if (useAndRefBlockSeqs._2.length > 0) {
-      currentScope.blockWaitlist += op -> useAndRefBlockSeqs._2
+    if (useAndRefBlockSeqs._1.length > 0) {
+      currentScope.blockWaitlist += op -> useAndRefBlockSeqs._1
     }
 
     return op

--- a/core/src/main/scala-3/builtin/Builtin.scala
+++ b/core/src/main/scala-3/builtin/Builtin.scala
@@ -326,13 +326,13 @@ case class DenseArrayAttr(
 ) extends ParametrizedAttribute("builtin.dense", Seq(typ, data))
     with Seq[Attribute] {
 
-  override def custom_verify(): Either[Unit, String] =
+  override def custom_verify(): Either[String, Unit] =
     if !data.forall(_ match {
         case IntegerAttr(_, eltyp) => eltyp == typ
         case FloatAttr(_, eltyp)   => eltyp == typ
       })
-    then Right("Element types do not match the dense array type")
-    else Left(())
+    then Left("Element types do not match the dense array type")
+    else Right(())
 
   override def custom_print = {
 
@@ -396,17 +396,17 @@ case class DenseIntOrFPElementsAttr(
 
   val int_or_float = BaseAttr[IntegerType | FloatType]()
 
-  override def custom_verify(): Either[Unit, String] =
+  override def custom_verify(): Either[String, Unit] =
     Try(int_or_float.verify(elementType, new ConstraintContext())) match {
       case Success(_) =>
         Try(
           for (x <- data.attrValues)
             int_or_float.verify(x, new ConstraintContext())
         ) match {
-          case Success(_) => Left(())
-          case Failure(e) => Right(e.getMessage)
+          case Success(_) => Right(())
+          case Failure(e) => Left(e.getMessage)
         }
-      case Failure(e) => Right(e.getMessage)
+      case Failure(e) => Left(e.getMessage)
     }
 
   override def custom_print = {

--- a/core/src/main/scala-3/ir/Attribute.scala
+++ b/core/src/main/scala-3/ir/Attribute.scala
@@ -18,7 +18,7 @@ import scair.Parser.*
 sealed trait Attribute {
   def name: String
   def prefix: String = "#"
-  def custom_verify(): Either[Unit, String] = Left(())
+  def custom_verify(): Either[String, Unit] = Right(())
   def custom_print: String
 }
 

--- a/core/src/main/scala-3/ir/Block.scala
+++ b/core/src/main/scala-3/ir/Block.scala
@@ -286,31 +286,31 @@ case class Block private (
 
   }
 
-  def verify(): Either[Unit, String] = {
+  def verify(): Either[String, Unit] = {
 
-    lazy val verifyRecArgs: Int => Either[Unit, String] = { (i: Int) =>
-      if i == arguments.length then Left(())
+    lazy val verifyRecArgs: Int => Either[String, Unit] = { (i: Int) =>
+      if i == arguments.length then Right(())
       else
         arguments(i).verify() match {
-          case Left(v)  => verifyRecArgs(i + 1)
-          case Right(x) => Right(x)
+          case Right(v)  => verifyRecArgs(i + 1)
+          case Left(x) => Left(x)
         }
     }
 
-    lazy val verifyRecOps: Int => Either[Unit, String] = { (i: Int) =>
-      if i == operations.length then Left(())
+    lazy val verifyRecOps: Int => Either[String, Unit] = { (i: Int) =>
+      if i == operations.length then Right(())
       else
         operations(i).verify() match {
-          case Left(v) =>
+          case Right(v) =>
             operations(i) = v
             verifyRecOps(i + 1)
-          case Right(x) => Right(x)
+          case Left(x) => Left(x)
         }
     }
 
     verifyRecArgs(0) match
-      case Left(_)  => verifyRecOps(0)
-      case Right(x) => Right(x)
+      case Right(_)  => verifyRecOps(0)
+      case Left(x) => Left(x)
   }
 
   override def equals(o: Any): Boolean = {

--- a/core/src/main/scala-3/ir/Block.scala
+++ b/core/src/main/scala-3/ir/Block.scala
@@ -291,26 +291,19 @@ case class Block private (
     lazy val verifyRecArgs: Int => Either[String, Unit] = { (i: Int) =>
       if i == arguments.length then Right(())
       else
-        arguments(i).verify() match {
-          case Right(v)  => verifyRecArgs(i + 1)
-          case Left(x) => Left(x)
-        }
+        arguments(i).verify().flatMap(_ => verifyRecArgs(i + 1))
     }
 
     lazy val verifyRecOps: Int => Either[String, Unit] = { (i: Int) =>
       if i == operations.length then Right(())
       else
-        operations(i).verify() match {
-          case Right(v) =>
+        operations(i).verify().flatMap(v =>
             operations(i) = v
             verifyRecOps(i + 1)
-          case Left(x) => Left(x)
-        }
+        )
     }
 
-    verifyRecArgs(0) match
-      case Right(_)  => verifyRecOps(0)
-      case Left(x) => Left(x)
+    verifyRecArgs(0).flatMap(_ => verifyRecOps(0))
   }
 
   override def equals(o: Any): Boolean = {

--- a/core/src/main/scala-3/ir/Operation.scala
+++ b/core/src/main/scala-3/ir/Operation.scala
@@ -67,34 +67,22 @@ trait Operation extends IRNode {
     lazy val verifyRes: Int => Either[String, Operation] = { (i: Int) =>
       if i == results.length then Right(this)
       else
-        results(i).verify() match {
-          case Right(v)  => verifyRes(i + 1)
-          case Left(x) => Left(x)
-        }
+        results(i).verify().flatMap(_ => verifyRes(i + 1))
     }
     lazy val verifyReg: Int => Either[String, Operation] = { (i: Int) =>
       if i == regions.length then Right(this)
       else
-        regions(i).verify() match {
-          case Right(v)  => verifyReg(i + 1)
-          case Left(x) => Left(x)
-        }
+        regions(i).verify().flatMap(_ => verifyReg(i + 1))
     }
     lazy val verifyProp: Int => Either[String, Operation] = { (i: Int) =>
       if i == properties.size then Right(this)
       else
-        properties.values.toSeq(i).custom_verify() match {
-          case Right(v)  => verifyProp(i + 1)
-          case Left(x) => Left(x)
-        }
+        properties.values.toSeq(i).custom_verify().flatMap(_ => verifyProp(i + 1))
     }
     lazy val verifyAttrs: Int => Either[String, Operation] = { (i: Int) =>
       if i == attributes.size then Right(this)
       else
-        attributes.values.toSeq(i).custom_verify() match {
-          case Right(v)  => verifyAttrs(i + 1)
-          case Left(x) => Left(x)
-        }
+        attributes.values.toSeq(i).custom_verify().flatMap(_ => verifyAttrs(i + 1))
     }
     verifyRes(0)
       .flatMap(

--- a/core/src/main/scala-3/ir/Region.scala
+++ b/core/src/main/scala-3/ir/Region.scala
@@ -24,14 +24,14 @@ case class Region(
     for (block <- blocks) block.drop_all_references
   }
 
-  def verify(): Either[Unit, String] = {
+  def verify(): Either[String, Unit] = {
 
-    lazy val verifyRecBlocks: Int => Either[Unit, String] = { (i: Int) =>
-      if i == blocks.length then Left(())
+    lazy val verifyRecBlocks: Int => Either[String, Unit] = { (i: Int) =>
+      if i == blocks.length then Right(())
       else
         blocks(i).verify() match {
-          case Left(v)  => verifyRecBlocks(i + 1)
-          case Right(x) => Right(x)
+          case Right(v)  => verifyRecBlocks(i + 1)
+          case Left(x) => Left(x)
         }
     }
 

--- a/core/src/main/scala-3/ir/Region.scala
+++ b/core/src/main/scala-3/ir/Region.scala
@@ -25,14 +25,9 @@ case class Region(
   }
 
   def verify(): Either[String, Unit] = {
-
-    lazy val verifyRecBlocks: Int => Either[String, Unit] = { (i: Int) =>
-      if i == blocks.length then Right(())
-      else
-        blocks(i).verify().flatMap(_ => verifyRecBlocks(i + 1))
-    }
-
-    verifyRecBlocks(0)
+    blocks.foldLeft[Either[String, Unit]](Right(()))((res, block) =>
+      res.flatMap(_ => block.verify())
+    )
   }
 
   override def equals(o: Any): Boolean = {

--- a/core/src/main/scala-3/ir/Region.scala
+++ b/core/src/main/scala-3/ir/Region.scala
@@ -29,10 +29,7 @@ case class Region(
     lazy val verifyRecBlocks: Int => Either[String, Unit] = { (i: Int) =>
       if i == blocks.length then Right(())
       else
-        blocks(i).verify() match {
-          case Right(v)  => verifyRecBlocks(i + 1)
-          case Left(x) => Left(x)
-        }
+        blocks(i).verify().flatMap(_ => verifyRecBlocks(i + 1))
     }
 
     verifyRecBlocks(0)

--- a/core/src/main/scala-3/ir/Traits.scala
+++ b/core/src/main/scala-3/ir/Traits.scala
@@ -13,21 +13,21 @@ package scair.ir
 
 trait IsTerminator extends Operation {
 
-  override def trait_verify(): Either[Operation, String] = {
+  override def trait_verify(): Either[String, Operation] = {
     {
       this.container_block match {
         case Some(b) =>
           if (this != b.operations.last) then
-            Right(
+            Left(
               s"Operation '${name}' marked as a terminator, but is not the last operation within its container block"
             )
-          else Left(this)
+          else Right(this)
         case None =>
-          Right(
+          Left(
             s"Operation '${name}' marked as a terminator, but is not contained in any block."
           )
       }
-    }.orElse(super.trait_verify())
+    }.flatMap(_ => super.trait_verify())
   }
 
 }
@@ -38,14 +38,14 @@ trait IsTerminator extends Operation {
 
 trait NoTerminator extends Operation {
 
-  override def trait_verify(): Either[Operation, String] = {
+  override def trait_verify(): Either[String, Operation] = {
     {
       if (regions.filter(x => x.blocks.length != 1).length != 0) then
-        Right(
+        Left(
           s"NoTerminator Operation '${name}' requires single-block regions"
         )
-      else Left(this)
-    }.orElse(super.trait_verify())
+      else Right(this)
+    }.flatMap(_ => super.trait_verify())
   }
 
 }

--- a/core/src/main/scala-3/ir/Value.scala
+++ b/core/src/main/scala-3/ir/Value.scala
@@ -63,7 +63,7 @@ class Value[+T <: Attribute](
       )
   }
 
-  def verify(): Either[Unit, String] = typ.custom_verify()
+  def verify(): Either[String, Unit] = typ.custom_verify()
 
   override def equals(o: Any): Boolean = {
     return this eq o.asInstanceOf[AnyRef]

--- a/core/test/src/scala-3/TraitTest.scala
+++ b/core/test/src/scala-3/TraitTest.scala
@@ -105,7 +105,7 @@ class TraitTest extends AnyFlatSpec with BeforeAndAfter {
 
       val exception = block.verify()
 
-      exception shouldBe Right(
+      exception shouldBe Left(
         "Operation 'terminator' marked as a terminator, but is not the last operation within its container block"
       )
     }
@@ -117,7 +117,7 @@ class TraitTest extends AnyFlatSpec with BeforeAndAfter {
 
       val exception = terminator.verify()
 
-      exception shouldBe Right(
+      exception shouldBe Left(
         "Operation 'terminator' marked as a terminator, but is not contained in any block."
       )
     }
@@ -167,7 +167,7 @@ class TraitTest extends AnyFlatSpec with BeforeAndAfter {
 
     val exception = noterminator.verify()
 
-    exception shouldBe Right(
+    exception shouldBe Left(
       "NoTerminator Operation 'noterminator' requires single-block regions"
     )
   }

--- a/dialects/src/main/scala-3/lingodb/DBOps.scala
+++ b/dialects/src/main/scala-3/lingodb/DBOps.scala
@@ -96,13 +96,13 @@ case class DB_CharType(val typ: Seq[Attribute])
     )
     with TypeAttribute {
 
-  override def custom_verify(): Either[Unit, String] = {
+  override def custom_verify(): Either[String, Unit] = {
     if (typ.length != 1) {
-      Right("TupleStream Tuple must contain 1 elements only.")
+      Left("TupleStream Tuple must contain 1 elements only.")
     } else
       typ(0) match {
-        case _: IntData => Left(())
-        case _          => Right("CharType type must be IntData")
+        case _: IntData => Right(())
+        case _          => Left("CharType type must be IntData")
       }
   }
 
@@ -189,19 +189,19 @@ case class DB_DecimalType(val typ: Seq[Attribute])
     )
     with TypeAttribute {
 
-  override def custom_verify(): Either[Unit, String] = {
+  override def custom_verify(): Either[String, Unit] = {
     if (typ.length != 2) {
-      Right("TupleStream Tuple must contain exactly 2 elements.")
+      Left("TupleStream Tuple must contain exactly 2 elements.")
     } else {
       typ(0) match {
-        case _: IntData => Left(())
+        case _: IntData => Right(())
         case _ =>
-          Right("DB_DecimalType type must be (IntData, IntData)")
+          Left("DB_DecimalType type must be (IntData, IntData)")
       }
       typ(1) match {
-        case _: IntData => Left(())
+        case _: IntData => Right(())
         case _ =>
-          Right("DB_DecimalType type must be (IntData, IntData)")
+          Left("DB_DecimalType type must be (IntData, IntData)")
       }
     }
   }
@@ -232,18 +232,18 @@ case class DB_StringType(val typ: Seq[Attribute])
     )
     with TypeAttribute {
 
-  override def custom_verify(): Either[Unit, String] = {
+  override def custom_verify(): Either[String, Unit] = {
     if (typ.length > 1) {
-      Right(
+      Left(
         "TupleStream Tuple must contain at most 1 element."
       )
     } else if (typ.length == 1)
       typ(0) match {
-        case _: StringData => Left(())
+        case _: StringData => Right(())
         case _ =>
-          Right("DB_DecimalType type must be StringData")
+          Left("DB_DecimalType type must be StringData")
       }
-    else Left(())
+    else Right(())
   }
 
   override def custom_print: String = {
@@ -303,16 +303,16 @@ case class DB_ConstantOp(
       attributes
     ) {
 
-  override def custom_verify(): Either[Operation, String] = (
+  override def custom_verify(): Either[String, Operation] = (
     operands.length,
     successors.length,
     results.length,
     regions.length,
     properties.size
   ) match {
-    case (0, 0, 1, 0, 0) => Left(this)
+    case (0, 0, 1, 0, 0) => Right(this)
     case _ =>
-      Right(
+      Left(
         "DB_ConstantOp Operation must contain only 2 dictionary attributes."
       )
   }
@@ -377,7 +377,7 @@ case class DB_CmpOp(
       attributes
     ) {
 
-  override def custom_verify(): Either[Operation, String] = (
+  override def custom_verify(): Either[String, Operation] = (
     operands.length,
     successors.length,
     results.length,
@@ -386,14 +386,14 @@ case class DB_CmpOp(
   ) match {
     case (2, 0, 0, 0, 0) =>
       (operands(0).typ == operands(1).typ) match {
-        case true => Left(this)
+        case true => Right(this)
         case false =>
-          Right(
+          Left(
             "In order to be compared, operands' types must match!"
           )
       }
     case _ =>
-      Right(
+      Left(
         "DB_CmpOp Operation must contain only 2 operands."
       )
   }
@@ -521,7 +521,7 @@ case class DB_MulOp(
       attributes
     ) {
 
-  override def custom_verify(): Either[Operation, String] = (
+  override def custom_verify(): Either[String, Operation] = (
     operands.length,
     successors.length,
     results.length,
@@ -530,14 +530,14 @@ case class DB_MulOp(
   ) match {
     case (2, 0, 1, 0, 0) =>
       (operands(0).typ == operands(1).typ) match {
-        case true => Left(this)
+        case true => Right(this)
         case false =>
-          Right(
+          Left(
             "In order to be multiplied, operands' types must match!"
           )
       }
     case _ =>
-      Right(
+      Left(
         "DB_MulOp Operation must contain only 2 operands."
       )
   }
@@ -667,7 +667,7 @@ case class DB_DivOp(
       attributes
     ) {
 
-  override def custom_verify(): Either[Operation, String] = (
+  override def custom_verify(): Either[String, Operation] = (
     operands.length,
     successors.length,
     results.length,
@@ -676,14 +676,14 @@ case class DB_DivOp(
   ) match {
     case (2, 0, 1, 0, 0) =>
       (operands(0).typ == operands(1).typ) match {
-        case true => Left(this)
+        case true => Right(this)
         case false =>
-          Right(
+          Left(
             "In order to be divided, operands' types must match!"
           )
       }
     case _ =>
-      Right(
+      Left(
         "DB_DivOp Operation must contain only 2 operands."
       )
   }
@@ -753,7 +753,7 @@ case class DB_AddOp(
       attributes
     ) {
 
-  override def custom_verify(): Either[Operation, String] = (
+  override def custom_verify(): Either[String, Operation] = (
     operands.length,
     successors.length,
     results.length,
@@ -762,14 +762,14 @@ case class DB_AddOp(
   ) match {
     case (2, 0, 1, 0, 0) =>
       (operands(0).typ == operands(1).typ) match {
-        case true => Left(this)
+        case true => Right(this)
         case false =>
-          Right(
+          Left(
             "In order to be added, operands' types must match!"
           )
       }
     case _ =>
-      Right(
+      Left(
         "DB_AddOp Operation must contain only 2 operands."
       )
   }
@@ -841,7 +841,7 @@ case class DB_SubOp(
       attributes
     ) {
 
-  override def custom_verify(): Either[Operation, String] = (
+  override def custom_verify(): Either[String, Operation] = (
     operands.length,
     successors.length,
     results.length,
@@ -850,14 +850,14 @@ case class DB_SubOp(
   ) match {
     case (2, 0, 1, 0, 0) =>
       (operands(0).typ == operands(1).typ) match {
-        case true => Left(this)
+        case true => Right(this)
         case false =>
-          Right(
+          Left(
             "In order to carry out substitution, operands' types must match!"
           )
       }
     case _ =>
-      Right(
+      Left(
         "DB_SubOp Operation must contain only 2 operands."
       )
   }
@@ -926,16 +926,16 @@ case class CastOp(
       attributes
     ) {
 
-  override def custom_verify(): Either[Operation, String] = (
+  override def custom_verify(): Either[String, Operation] = (
     operands.length,
     successors.length,
     results.length,
     regions.length,
     properties.size
   ) match {
-    case (1, 0, 1, 0, 0) => Left(this)
+    case (1, 0, 1, 0, 0) => Right(this)
     case _ =>
-      Right(
+      Left(
         "CastOp Operation must contain only 1 operand and result."
       )
   }

--- a/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
+++ b/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
@@ -199,7 +199,7 @@ case class BaseTableOp(
       attributes
     ) {
 
-  override def custom_verify(): Either[Operation, String] = (
+  override def custom_verify(): Either[String, Operation] = (
     operands.length,
     successors.length,
     results.length,
@@ -208,24 +208,24 @@ case class BaseTableOp(
     case (0, 0, 1, 0) =>
       {
         results(0).typ match {
-          case _: TupleStream => Left(this)
+          case _: TupleStream => Right(this)
           case _ =>
-            Right(
+            Left(
               "BaseTableOp Operation must contain only 1 result."
             )
         }
-      }.orElse({
+      }.flatMap(_ => {
         attributes.get("table_identifier") match {
           case Some(x) =>
             x match {
-              case _: StringData => Left(this)
+              case _: StringData => Right(this)
               case _ =>
-                Right(
+                Left(
                   "BaseTableOp Operation must contain a StringAttr named 'table_identifier'."
                 )
             }
           case None =>
-            Right(
+            Left(
               "BaseTableOp Operation must contain a StringAttr named 'table_identifier'."
             )
         }
@@ -285,7 +285,7 @@ case class SelectionOp(
       attributes
     ) {
 
-  override def custom_verify(): Either[Operation, String] = (
+  override def custom_verify(): Either[String, Operation] = (
     operands.length,
     successors.length,
     results.length,
@@ -294,17 +294,17 @@ case class SelectionOp(
     case (1, 0, 1, 1) =>
       {
         operands(0).typ match {
-          case _: TupleStream => Left(this)
+          case _: TupleStream => Right(this)
           case _ =>
-            Right(
+            Left(
               "SelectionOp Operation must contain only 1 operand of type TupleStream."
             )
         }
-      }.orElse({
+      }.flatMap(_ =>{
         results(0).typ match {
-          case _: TupleStream => Left(this)
+          case _: TupleStream => Right(this)
           case _ =>
-            Right(
+            Left(
               "SelectionOp Operation must contain only 1 result of type TupleStream."
             )
         }
@@ -367,7 +367,7 @@ case class MapOp(
       attributes
     ) {
 
-  override def custom_verify(): Either[Operation, String] = (
+  override def custom_verify(): Either[String, Operation] = (
     operands.length,
     successors.length,
     results.length,
@@ -376,38 +376,38 @@ case class MapOp(
     case (1, 0, 1, 1) =>
       {
         operands(0).typ match {
-          case _: TupleStream => Left(this)
+          case _: TupleStream => Right(this)
           case _ =>
-            Right(
+            Left(
               "MapOp Operation must contain only 1 operand of type TupleStream."
             )
         }
-      }.orElse({
+      }.flatMap(_ =>{
         results(0).typ match {
-          case _: TupleStream => Left(this)
+          case _: TupleStream => Right(this)
           case _ =>
-            Right(
+            Left(
               "MapOp Operation must contain only 1 result of type TupleStream."
             )
         }
-      }).orElse({
+      }).flatMap(_ =>{
         attributes.get("computed_cols") match {
           case Some(x) =>
             x match {
-              case _: ArrayAttribute[_] => Left(this)
+              case _: ArrayAttribute[_] => Right(this)
               case _ =>
-                Right(
+                Left(
                   "MapOp Operation must contain a ArrayAttribute named 'computed_cols'."
                 )
             }
           case None =>
-            Right(
+            Left(
               "MapOp Operation must contain a ArrayAttribute named 'computed_cols'."
             )
         }
       })
     case _ =>
-      Right(
+      Left(
         "MapOp Operation must contain only 1 operand, 1 result and 1 region."
       )
   }
@@ -476,7 +476,7 @@ case class AggregationOp(
       attributes
     ) {
 
-  override def custom_verify(): Either[Operation, String] = (
+  override def custom_verify(): Either[String, Operation] = (
     operands.length,
     successors.length,
     results.length,
@@ -485,52 +485,52 @@ case class AggregationOp(
     case (1, 0, 1, 1) =>
       {
         operands(0).typ match {
-          case _: TupleStream => Left(this)
+          case _: TupleStream => Right(this)
           case _ =>
-            Right(
+            Left(
               "AggregationOp Operation must contain only 1 operand of type TupleStream."
             )
         }
         results(0).typ match {
-          case _: TupleStream => Left(this)
+          case _: TupleStream => Right(this)
           case _ =>
-            Right(
+            Left(
               "AggregationOp Operation must contain only 1 result of type TupleStream."
             )
         }
-      }.orElse({
+      }.flatMap(_ => {
         attributes.get("computed_cols") match {
           case Some(x) =>
             x match {
-              case _: ArrayAttribute[_] => Left(this)
+              case _: ArrayAttribute[_] => Right(this)
               case _ =>
-                Right(
+                Left(
                   "AggregationOp Operation must contain an ArrayAttribute named 'computed_cols'."
                 )
             }
           case _ =>
-            Right(
+            Left(
               "AggregationOp Operation must contain an ArrayAttribute named 'computed_cols'."
             )
         }
-      }).orElse({
+      }).flatMap(_ => {
         attributes.get("group_by_cols") match {
           case Some(x) =>
             x match {
-              case _: ArrayAttribute[_] => Left(this)
+              case _: ArrayAttribute[_] => Right(this)
               case _ =>
-                Right(
+                Left(
                   "AggregationOp Operation must contain an ArrayAttribute named 'group_by_cols'."
                 )
             }
           case _ =>
-            Right(
+            Left(
               "AggregationOp Operation must contain an ArrayAttribute named 'group_by_cols'."
             )
         }
       })
     case _ =>
-      Right(
+      Left(
         "AggregationOp Operation must contain only 1 operand, 1 result and 1 region."
       )
   }
@@ -584,7 +584,7 @@ case class CountRowsOp(
       attributes
     ) {
 
-  override def custom_verify(): Either[Operation, String] = (
+  override def custom_verify(): Either[String, Operation] = (
     operands.length,
     successors.length,
     results.length,
@@ -593,23 +593,23 @@ case class CountRowsOp(
     case (1, 0, 1, 0) =>
       {
         operands(0).typ match {
-          case _: TupleStream => Left(this)
+          case _: TupleStream => Right(this)
           case _ =>
-            Right(
+            Left(
               "CountRowsOp Operation must contain 1 operand of type TupleStream."
             )
         }
-      }.orElse({
+      }.flatMap(_ =>{
         results(0).typ match {
-          case _: IntegerType => Left(this)
+          case _: IntegerType => Right(this)
           case _ =>
-            Right(
+            Left(
               "CountRowsOp Operation must contain only 1 result of IntegerType."
             )
         }
       })
     case _ =>
-      Right(
+      Left(
         "CountRowsOp Operation must contain only 1 operand and 1 result."
       )
   }
@@ -668,7 +668,7 @@ case class AggrFuncOp(
       attributes
     ) {
 
-  override def custom_verify(): Either[Operation, String] = (
+  override def custom_verify(): Either[String, Operation] = (
     operands.length,
     successors.length,
     results.length,
@@ -677,45 +677,45 @@ case class AggrFuncOp(
     case (1, 0, 1, 0) =>
       {
         operands(0).typ match {
-          case _: TupleStream => Left(this)
+          case _: TupleStream => Right(this)
           case _ =>
-            Right(
+            Left(
               "AggrFuncOp Operation must contain 1 operand of type TupleStream."
             )
         }
-      }.orElse({
+      }.flatMap(_ => {
         attributes.get("fn") match {
           case Some(x) =>
             x match {
-              case _: RelAlg_AggrFunc_Case => Left(this)
+              case _: RelAlg_AggrFunc_Case => Right(this)
               case _ =>
-                Right(
+                Left(
                   "AggrFuncOp Operation must contain an RelAlg_AggrFunc enum named 'fn'."
                 )
             }
           case _ =>
-            Right(
+            Left(
               "AggrFuncOp Operation must contain an RelAlg_AggrFunc enum named 'fn'."
             )
         }
-      }).orElse({
+      }).flatMap(_ => {
         attributes.get("attr") match {
           case Some(x) =>
             x match {
-              case _: ColumnRefAttr => Left(this)
+              case _: ColumnRefAttr => Right(this)
               case _ =>
-                Right(
+                Left(
                   "AggrFuncOp Operation must contain an ColumnRefAttr named 'attr'."
                 )
             }
           case _ =>
-            Right(
+            Left(
               "AggrFuncOp Operation must contain an ColumnRefAttr named 'attr'."
             )
         }
       })
     case _ =>
-      Right(
+      Left(
         "AggrFuncOp Operation must contain only 1 operand and 1 result."
       )
   }
@@ -775,7 +775,7 @@ case class SortOp(
       attributes
     ) {
 
-  override def custom_verify(): Either[Operation, String] = (
+  override def custom_verify(): Either[String, Operation] = (
     operands.length,
     successors.length,
     results.length,
@@ -784,38 +784,38 @@ case class SortOp(
     case (1, 0, 1, 0) =>
       {
         operands(0).typ match {
-          case _: TupleStream => Left(this)
+          case _: TupleStream => Right(this)
           case _ =>
-            Right(
+            Left(
               "SortOp Operation must contain 1 operand of type TupleStream."
             )
         }
-      }.orElse({
+      }.flatMap(_ =>{
         results(0).typ match {
-          case _: TupleStream => Left(this)
+          case _: TupleStream => Right(this)
           case _ =>
-            Right(
+            Left(
               "SortOp Operation must contain 1 operand of type TupleStream."
             )
         }
-      }).orElse({
+      }).flatMap(_ =>{
         attributes.get("sortspecs") match {
           case Some(x) =>
             x match {
-              case _: ArrayAttribute[_] => Left(this)
+              case _: ArrayAttribute[_] => Right(this)
               case _ =>
-                Right(
+                Left(
                   "SortOp Operation must contain an ArrayAttribute enum named 'sortspecs'."
                 )
             }
           case _ =>
-            Right(
+            Left(
               "SortOp Operation must contain an ArrayAttribute enum named 'sortspecs'."
             )
         }
       })
     case _ =>
-      Right(
+      Left(
         "SortOp Operation must contain only 1 operand and 1 result."
       )
   }
@@ -881,7 +881,7 @@ case class MaterializeOp(
       attributes
     ) {
 
-  override def custom_verify(): Either[Operation, String] = (
+  override def custom_verify(): Either[String, Operation] = (
     operands.length,
     successors.length,
     results.length,
@@ -890,53 +890,53 @@ case class MaterializeOp(
     case (1, 0, 1, 0) =>
       {
         operands(0).typ match {
-          case _: TupleStream => Left(this)
+          case _: TupleStream => Right(this)
           case _ =>
-            Right(
+            Left(
               "MaterializeOp Operation must contain 1 operand of type TupleStream."
             )
         }
-      }.orElse({
+      }.flatMap(_ => {
         results(0).typ match {
-          case _: ResultTable => Left(this)
+          case _: ResultTable => Right(this)
           case _ =>
-            Right(
+            Left(
               "MaterializeOp Operation must contain 1 operand of type ResultOp."
             )
         }
-      }).orElse({
+      }).flatMap(_ => {
         attributes.get("cols") match {
           case Some(x) =>
             x match {
-              case _: ArrayAttribute[_] => Left(this)
+              case _: ArrayAttribute[_] => Right(this)
               case _ =>
-                Right(
+                Left(
                   "MaterializeOp Operation must contain an ArrayAttribute enum named 'cols'."
                 )
             }
           case _ =>
-            Right(
+            Left(
               "MaterializeOp Operation must contain an ArrayAttribute enum named 'cols'."
             )
         }
-      }).orElse({
+      }).flatMap(_ => {
         attributes.get("columns") match {
           case Some(x) =>
             x match {
-              case _: ArrayAttribute[_] => Left(this)
+              case _: ArrayAttribute[_] => Right(this)
               case _ =>
-                Right(
+                Left(
                   "MaterializeOp Operation must contain an ArrayAttribute named 'columns'."
                 )
             }
           case _ =>
-            Right(
+            Left(
               "MaterializeOp Operation must contain an ArrayAttribute named 'columns'."
             )
         }
       })
     case _ =>
-      Right(
+      Left(
         "MaterializeOp Operation must contain only 1 operand and 1 result."
       )
   }

--- a/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
+++ b/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
@@ -300,7 +300,7 @@ case class SelectionOp(
               "SelectionOp Operation must contain only 1 operand of type TupleStream."
             )
         }
-      }.flatMap(_ =>{
+      }.flatMap(_ => {
         results(0).typ match {
           case _: TupleStream => Right(this)
           case _ =>
@@ -382,7 +382,7 @@ case class MapOp(
               "MapOp Operation must contain only 1 operand of type TupleStream."
             )
         }
-      }.flatMap(_ =>{
+      }.flatMap(_ => {
         results(0).typ match {
           case _: TupleStream => Right(this)
           case _ =>
@@ -390,7 +390,7 @@ case class MapOp(
               "MapOp Operation must contain only 1 result of type TupleStream."
             )
         }
-      }).flatMap(_ =>{
+      }).flatMap(_ => {
         attributes.get("computed_cols") match {
           case Some(x) =>
             x match {
@@ -599,7 +599,7 @@ case class CountRowsOp(
               "CountRowsOp Operation must contain 1 operand of type TupleStream."
             )
         }
-      }.flatMap(_ =>{
+      }.flatMap(_ => {
         results(0).typ match {
           case _: IntegerType => Right(this)
           case _ =>
@@ -790,7 +790,7 @@ case class SortOp(
               "SortOp Operation must contain 1 operand of type TupleStream."
             )
         }
-      }.flatMap(_ =>{
+      }.flatMap(_ => {
         results(0).typ match {
           case _: TupleStream => Right(this)
           case _ =>
@@ -798,7 +798,7 @@ case class SortOp(
               "SortOp Operation must contain 1 operand of type TupleStream."
             )
         }
-      }).flatMap(_ =>{
+      }).flatMap(_ => {
         attributes.get("sortspecs") match {
           case Some(x) =>
             x match {

--- a/dialects/src/main/scala-3/lingodb/SubOperatorOps.scala
+++ b/dialects/src/main/scala-3/lingodb/SubOperatorOps.scala
@@ -123,7 +123,7 @@ case class SetResultOp(
       attributes
     ) {
 
-  override def custom_verify(): Either[Operation, String] = (
+  override def custom_verify(): Either[String, Operation] = (
     operands.length,
     successors.length,
     results.length,
@@ -134,19 +134,19 @@ case class SetResultOp(
       attributes.get("result_id") match {
         case Some(x) =>
           x match {
-            case _: IntegerAttr => Left(this)
+            case _: IntegerAttr => Right(this)
             case _ =>
-              Right(
+              Left(
                 "SetResultOp Operation's 'result_id' must be of type IntegerAttr."
               )
           }
         case _ =>
-          Right(
+          Left(
             "SetResultOp Operation's 'result_id' must be of type IntegerAttr."
           )
       }
     case _ =>
-      Right(
+      Left(
         "SetResultOp Operation must have 1 operand, 0 successors, 0 results, 0 regions and 0 properties."
       )
   }

--- a/dialects/src/main/scala-3/lingodb/TupleStream.scala
+++ b/dialects/src/main/scala-3/lingodb/TupleStream.scala
@@ -73,7 +73,7 @@ case class TupleStream(val tuples: Seq[Attribute])
       tuples(i) match {
         case x: TupleStreamTuple =>
           x.custom_verify() match {
-            case Right(_)    => verifyTuples(i + 1)
+            case Right(_)  => verifyTuples(i + 1)
             case Left(err) => Left(err)
           }
         case _ =>
@@ -268,7 +268,7 @@ case class GetColumnOp(
           case x: TupleStreamTuple =>
             x.custom_verify() match {
               case Right(value) => Right(this)
-              case Left(err)  => Left(err)
+              case Left(err)    => Left(err)
             }
           case _ =>
             Left(

--- a/dialects/src/main/scala-3/math/Math.scala
+++ b/dialects/src/main/scala-3/math/Math.scala
@@ -52,16 +52,16 @@ case class AbsfOp(
       attributes
     ) {
 
-  override def custom_verify(): Either[Operation, String] = (
+  override def custom_verify(): Either[String, Operation] = (
     operands.length,
     results.length,
     successors.length,
     regions.length,
     properties.size
   ) match {
-    case (1, 1, 0, 0, 0) => Left(this)
+    case (1, 1, 0, 0, 0) => Right(this)
     case _ =>
-      Right(
+      Left(
         "AbsfOp must have 1 result and 1 operand."
       )
   }
@@ -115,16 +115,16 @@ case class FPowIOp(
       attributes
     ) {
 
-  override def custom_verify(): Either[Operation, String] = (
+  override def custom_verify(): Either[String, Operation] = (
     operands.length,
     results.length,
     successors.length,
     regions.length,
     properties.size
   ) match {
-    case (2, 1, 0, 0, 0) => Left(this)
+    case (2, 1, 0, 0, 0) => Right(this)
     case _ =>
-      Right(
+      Left(
         "FPowIOp must have 1 result and 2 operands."
       )
   }

--- a/tools/src/main/scala-3/ScairOpt.scala
+++ b/tools/src/main/scala-3/ScairOpt.scala
@@ -102,7 +102,7 @@ object ScairOpt {
                 var module = input_module
                 // verify parsed content
                 if (!skip_verify) module.verify() match {
-                  case Left(op) =>
+                  case Right(op) =>
                     // apply the specified passes
                     val transformCtx = new TransformContext()
                     transformCtx.register_all_passes()
@@ -111,15 +111,15 @@ object ScairOpt {
                         case Some(pass) =>
                           module = pass.transform(module)
                           module = module.verify() match {
-                            case Left(op) => op
-                            case Right(errorMsg) =>
+                            case Right(op) => op
+                            case Left(errorMsg) =>
                               throw new VerifyException(errorMsg)
                           }
                         case None =>
                       }
                     }
                     module
-                  case Right(errorMsg) =>
+                  case Left(errorMsg) =>
                     if (args.verify_diagnostics) {
                       errorMsg
                     } else {
@@ -134,8 +134,8 @@ object ScairOpt {
                       case Some(pass) =>
                         module = pass.transform(module)
                         module.verify() match {
-                          case Left(_) =>
-                          case Right(errorMsg) =>
+                          case Right(_) =>
+                          case Left(errorMsg) =>
                             throw new VerifyException(errorMsg)
                         }
                       case None =>


### PR DESCRIPTION
https://www.scala-lang.org/api/3.x/scala/util/Either.html:
> Convention dictates that Left is used for failure and Right is used for success.

Used it to use more idiomatic functional constructs in core verification logic.