### PR TITLE
Add documentation snippets compilation

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -26,10 +26,10 @@ trait ScairSettings extends ScalaModule with UnidocModule {
 
   def scoverageVersion = T{"2.3.0"}
   override def scalaVersion = "3.6.4"
-  override def scalacOptions = Seq("-Wunused:imports")
+  override def scalacOptions = super.scalacOptions() ++ Seq("-Wunused:imports")
+  override def unidocOptions = super.unidocOptions() ++ Seq("-snippet-compiler:compile")
 
   override def unidocVersion: T[Option[String]] = Some("0.5.0")
-  override def scalaDocOptions = Seq("-Xsource:3", "-snippet-compiler:compile")
 
   override def unidocSourceFiles = Task {
       (Seq(compile().classes) ++ T.traverse(transitiveModuleDeps)(_.compile)().map(_.classes))

--- a/clair/src/main/scala-3/package.scala
+++ b/clair/src/main/scala-3/package.scala
@@ -10,13 +10,16 @@ package scair
   * example:
   *
   * ```scala
-  * import scair.ir.{DataAttribute, AttributeObject}
+  * import scair.ir.*
+  * import scair.clair.macros.*
+  * import scair.dialects.builtin.*
+  * import scair.dialects.cmath.*
   *
   * /*≡≡=---=≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡=---=≡≡*\
   * ||   defining a custom data attribute   ||
   * \*≡==----=≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡=----==≡*/
   *
-  * object SampleData extends AttributeObject {
+  * object SampleData extends AttributeCompanion {
   *   override def name: String = "sample"
   * }
   *
@@ -34,7 +37,7 @@ package scair
   *       parameters = Seq(value)
   *     )
   *     with MLIRName["sample.sample_attr"]
-  *     derives AttributeTrait
+  *     derives DerivedAttributeCompanion
   *
   * /*≡≡=---=≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡=---=≡≡*\
   * ||   defining a custom type attribute   ||
@@ -48,7 +51,7 @@ package scair
   *     )
   *     with TypeAttribute
   *     with MLIRName["sample.sample_type"]
-  *     derives AttributeTrait
+  *     derives DerivedAttributeCompanion
   *
   * /*≡≡=---=≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡=---=≡≡*\
   * ||   defining custom operations   ||


### PR DESCRIPTION
All Scala snippets in the documentation will be compiled and reporting documentation-compilation errors if there's a problem, ensuring they stay relatively up to date.
Note that this is the default setting for the whole repository now, but this is very configurable, including at the snippet level:
https://docs.scala-lang.org/scala3/guides/scaladoc/snippet-compiler.html

We can provide snippets without any checks, or even snippets ensuring a compilation error to showcase helpful ones :slightly_smiling_face: 