### PR TITLE
Unifying the derivation API for Attributes

### DIFF
--- a/clair/src/main/scala-3/Macros.scala
+++ b/clair/src/main/scala-3/Macros.scala
@@ -647,7 +647,9 @@ def ADTFlatAttrInputMacro[Def <: AttributeDef: Type](
     adtAttrExpr: Expr[?]
 )(using Quotes): Expr[Seq[Attribute]] = {
   Expr.ofList(
-    attrInputDefs.map(d => selectMember(adtAttrExpr, d.name).asExprOf[Attribute])
+    attrInputDefs.map(d =>
+      selectMember(adtAttrExpr, d.name).asExprOf[Attribute]
+    )
   )
 }
 
@@ -672,7 +674,10 @@ trait DerivedAttribute[name <: String, T] extends ParametrizedAttribute {
 
   given companion: DerivedAttributeCompanion[T] = deferred
   override val name: String = companion.name
-  override val parameters: Seq[Attribute | Seq[Attribute]] = companion.parameters(this)
+
+  override val parameters: Seq[Attribute | Seq[Attribute]] =
+    companion.parameters(this)
+
 }
 
 object DerivedAttributeCompanion {
@@ -690,8 +695,8 @@ object DerivedAttributeCompanion {
           ("<" ~/ p.Type.rep(sep = ",") ~ ">")
         ).orElse(Seq())
           .map(x => ${ getAttrConstructor[T](attrDef, '{ x }) })
-        def parameters(attr: T): Seq[Attribute | Seq[Attribute]] = ${ 
-          parametersMacro(attrDef, '{ attr }) 
+        def parameters(attr: T): Seq[Attribute | Seq[Attribute]] = ${
+          parametersMacro(attrDef, '{ attr })
         }
       }
     }

--- a/clair/src/main/scala-3/Macros.scala
+++ b/clair/src/main/scala-3/Macros.scala
@@ -647,7 +647,17 @@ def getAttrConstructor[T: Type](
 \*≡==---==≡≡==---==≡*/
 
 trait DerivedAttributeCompanion[T] extends AttributeCompanionI[T] {
+  def parameters(attr: T): Seq[Attribute | Seq[Attribute]]
   extension (op: T) override def AttributeTrait = this
+}
+
+trait DerivedAttribute[name <: String, T] extends ParametrizedAttribute {
+
+  this: T =>
+
+  given companion: DerivedAttributeCompanion[T] = deferred
+  override val name: String = companion.name
+  override val parameters: Seq[Attribute | Seq[Attribute]] = companion.parameters(this)
 }
 
 object DerivedAttributeCompanion {
@@ -665,6 +675,7 @@ object DerivedAttributeCompanion {
           ("<" ~/ p.Type.rep(sep = ",") ~ ">")
         ).orElse(Seq())
           .map(x => ${ getAttrConstructor[T](attrDef, '{ x }) })
+        def parameters(attr: T): Seq[Attribute | Seq[Attribute]] = Seq()
       }
     }
 

--- a/clair/src/main/scala-3/package.scala
+++ b/clair/src/main/scala-3/package.scala
@@ -32,11 +32,7 @@ package scair
   *
   * case class SampleAttr(
   *     val value: FloatType
-  * ) extends ParametrizedAttribute(
-  *       name = "sample.sample_attr",
-  *       parameters = Seq(value)
-  *     )
-  *     with MLIRName["sample.sample_attr"]
+  * ) extends DerivedAttribute["sample.sample_attr", SampleAttr]
   *     derives DerivedAttributeCompanion
   *
   * /*≡≡=---=≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡=---=≡≡*\
@@ -45,12 +41,8 @@ package scair
   *
   * case class SampleType(
   *     val value: FloatType
-  * ) extends ParametrizedAttribute(
-  *       name = "sample.sample_type",
-  *       parameters = Seq(value)
-  *     )
+  * ) extends DerivedAttribute["sample.sample_type", SampleType]
   *     with TypeAttribute
-  *     with MLIRName["sample.sample_type"]
   *     derives DerivedAttributeCompanion
   *
   * /*≡≡=---=≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡=---=≡≡*\

--- a/core/src/main/scala-3/builtin/Builtin.scala
+++ b/core/src/main/scala-3/builtin/Builtin.scala
@@ -51,7 +51,8 @@ case object Signless extends Signedness("signless", "i")
 ||    FLOAT TYPE    ||
 \*≡==---==≡≡==---==≡*/
 
-abstract class FloatType(override val name: String) extends ParametrizedAttribute
+abstract class FloatType(override val name: String)
+    extends ParametrizedAttribute
 
 case object Float16Type extends FloatType("builtin.f16") with TypeAttribute {
   override def custom_print = "f16"
@@ -156,9 +157,7 @@ case class FloatAttr(val value: FloatData, val typ: FloatType)
 ||   INDEX TYPE     ||
 \*≡==---==≡≡==---==≡*/
 
-case object IndexType
-    extends ParametrizedAttribute
-    with TypeAttribute {
+case object IndexType extends ParametrizedAttribute with TypeAttribute {
   override def name: String = "builtin.index"
   override def custom_print = "index"
 }
@@ -297,6 +296,7 @@ case class VectorType(
 ) extends ParametrizedAttribute {
 
   override def name: String = "builtin.vector_type"
+
   override def parameters: Seq[Attribute | Seq[Attribute]] =
     Seq(shape, elementType, scalableDims)
 
@@ -324,6 +324,7 @@ case class SymbolRefAttr(
 ) extends ParametrizedAttribute {
 
   override def name: String = "builtin.symbol_ref"
+
   override def parameters: Seq[Attribute | Seq[Attribute]] =
     Seq(rootRef, nestedRefs)
 
@@ -382,6 +383,7 @@ case class FunctionType(
     with TypeAttribute {
 
   override def name: String = "builtin.function_type"
+
   override def parameters: Seq[Attribute | Seq[Attribute]] =
     Seq(inputs, outputs)
 

--- a/core/src/main/scala-3/builtin/Builtin.scala
+++ b/core/src/main/scala-3/builtin/Builtin.scala
@@ -52,7 +52,9 @@ case object Signless extends Signedness("signless", "i")
 \*≡==---==≡≡==---==≡*/
 
 abstract class FloatType(override val name: String)
-    extends ParametrizedAttribute
+    extends ParametrizedAttribute {
+  override def parameters: Seq[Attribute | Seq[Attribute]] = Seq()
+}
 
 case object Float16Type extends FloatType("builtin.f16") with TypeAttribute {
   override def custom_print = "f16"
@@ -160,6 +162,7 @@ case class FloatAttr(val value: FloatData, val typ: FloatType)
 case object IndexType extends ParametrizedAttribute with TypeAttribute {
   override def name: String = "builtin.index"
   override def custom_print = "index"
+  override def parameters: Seq[Attribute | Seq[Attribute]] = Seq()
 }
 
 /*≡==--==≡≡≡≡==--=≡≡*\
@@ -411,6 +414,7 @@ case class DenseIntOrFPElementsAttr(
 ) extends ParametrizedAttribute {
 
   override def name: String = "builtin.dense"
+  override def parameters: Seq[Attribute | Seq[Attribute]] = Seq(typ, data)
 
   def elementType = typ match {
     case x: TensorType => x.elementType

--- a/core/src/main/scala-3/builtin/Builtin.scala
+++ b/core/src/main/scala-3/builtin/Builtin.scala
@@ -51,7 +51,7 @@ case object Signless extends Signedness("signless", "i")
 ||    FLOAT TYPE    ||
 \*≡==---==≡≡==---==≡*/
 
-abstract class FloatType(val namee: String) extends ParametrizedAttribute(namee)
+abstract class FloatType(override val name: String) extends ParametrizedAttribute
 
 case object Float16Type extends FloatType("builtin.f16") with TypeAttribute {
   override def custom_print = "f16"
@@ -88,8 +88,11 @@ case class IntData(val value: Long)
 \*≡==---==≡≡==---==≡*/
 
 case class IntegerType(val width: IntData, val sign: Signedness)
-    extends ParametrizedAttribute("builtin.int_type", Seq(width, sign))
+    extends ParametrizedAttribute
     with TypeAttribute {
+
+  override def name: String = "builtin.int_type"
+  override def parameters: Seq[Attribute | Seq[Attribute]] = Seq(width, sign)
 
   override def custom_print = sign match {
     case Signless => s"${sign.custom_print}${width.custom_print}"
@@ -106,9 +109,12 @@ case class IntegerType(val width: IntData, val sign: Signedness)
 case class IntegerAttr(
     val value: IntData,
     val typ: IntegerType | IndexType.type
-) extends ParametrizedAttribute("builtin.integer_attr", Seq(value, typ)) {
+) extends ParametrizedAttribute {
 
   def this(value: IntData) = this(value, I64)
+
+  override def name: String = "builtin.integer_attr"
+  override def parameters: Seq[Attribute | Seq[Attribute]] = Seq(value, typ)
 
   override def custom_print = (value, typ) match {
     case (IntData(1), IntegerType(IntData(1), Signless)) => "true"
@@ -134,7 +140,10 @@ case class FloatData(val value: Double)
 \*≡==---==≡≡==---==≡*/
 
 case class FloatAttr(val value: FloatData, val typ: FloatType)
-    extends ParametrizedAttribute("builtin.float_attr", Seq(value, typ)) {
+    extends ParametrizedAttribute {
+
+  override def name: String = "builtin.float_attr"
+  override def parameters: Seq[Attribute | Seq[Attribute]] = Seq(value, typ)
 
   override def custom_print = (value, typ) match {
     case (_, Float64Type) => s"${value.custom_print}"
@@ -148,8 +157,9 @@ case class FloatAttr(val value: FloatData, val typ: FloatType)
 \*≡==---==≡≡==---==≡*/
 
 case object IndexType
-    extends ParametrizedAttribute("builtin.index")
+    extends ParametrizedAttribute
     with TypeAttribute {
+  override def name: String = "builtin.index"
   override def custom_print = "index"
 }
 
@@ -188,8 +198,10 @@ abstract class TensorType(
     override val name: String,
     val elementType: Attribute,
     val features: Seq[Attribute]
-) extends ParametrizedAttribute(name, features)
-    with TypeAttribute
+) extends ParametrizedAttribute
+    with TypeAttribute {
+  override def parameters: Seq[Attribute | Seq[Attribute]] = features
+}
 
 case class RankedTensorType(
     val dimensionList: ArrayAttribute[IntData],
@@ -238,8 +250,10 @@ abstract class MemrefType(
     override val name: String,
     val elementType: Attribute,
     val features: Seq[Attribute]
-) extends ParametrizedAttribute(name, features)
-    with TypeAttribute
+) extends ParametrizedAttribute
+    with TypeAttribute {
+  override def parameters: Seq[Attribute | Seq[Attribute]] = features
+}
 
 case class RankedMemrefType(
     val shape: Seq[IntData],
@@ -280,10 +294,11 @@ case class VectorType(
     val shape: Seq[IntData],
     val elementType: Attribute,
     val scalableDims: Seq[IntData]
-) extends ParametrizedAttribute(
-      name = "builtin.vector",
-      parameters = Seq(shape, elementType, scalableDims)
-    ) {
+) extends ParametrizedAttribute {
+
+  override def name: String = "builtin.vector_type"
+  override def parameters: Seq[Attribute | Seq[Attribute]] =
+    Seq(shape, elementType, scalableDims)
 
   override def custom_print: String = {
 
@@ -306,10 +321,11 @@ case class VectorType(
 case class SymbolRefAttr(
     val rootRef: StringData,
     val nestedRefs: Seq[StringData] = Seq()
-) extends ParametrizedAttribute(
-      name = "builtin.symbol_ref",
-      Seq(rootRef, nestedRefs)
-    ) {
+) extends ParametrizedAttribute {
+
+  override def name: String = "builtin.symbol_ref"
+  override def parameters: Seq[Attribute | Seq[Attribute]] =
+    Seq(rootRef, nestedRefs)
 
   override def custom_print =
     (rootRef +: nestedRefs).map(_.data).map("@" + _).mkString("::")
@@ -323,8 +339,11 @@ case class SymbolRefAttr(
 case class DenseArrayAttr(
     val typ: IntegerType | FloatType,
     val data: Seq[IntegerAttr] | Seq[FloatAttr]
-) extends ParametrizedAttribute("builtin.dense", Seq(typ, data))
+) extends ParametrizedAttribute
     with Seq[Attribute] {
+
+  override def name: String = "builtin.dense_array"
+  override def parameters: Seq[Attribute | Seq[Attribute]] = Seq(typ, data)
 
   override def custom_verify(): Either[String, Unit] =
     if !data.forall(_ match {
@@ -359,11 +378,12 @@ case class DenseArrayAttr(
 case class FunctionType(
     val inputs: Seq[Attribute],
     val outputs: Seq[Attribute]
-) extends ParametrizedAttribute(
-      "builtin.function_type",
-      Seq(inputs, outputs)
-    )
+) extends ParametrizedAttribute
     with TypeAttribute {
+
+  override def name: String = "builtin.function_type"
+  override def parameters: Seq[Attribute | Seq[Attribute]] =
+    Seq(inputs, outputs)
 
   override def custom_print = {
     val inputsString = inputs.map(_.custom_print).mkString(", ")
@@ -386,7 +406,9 @@ type TensorLiteralArray =
 case class DenseIntOrFPElementsAttr(
     val typ: TensorType | MemrefType | VectorType,
     val data: TensorLiteralArray
-) extends ParametrizedAttribute("builtin.dense") {
+) extends ParametrizedAttribute {
+
+  override def name: String = "builtin.dense"
 
   def elementType = typ match {
     case x: TensorType => x.elementType

--- a/core/src/main/scala-3/builtin/EnumAttr.scala
+++ b/core/src/main/scala-3/builtin/EnumAttr.scala
@@ -27,7 +27,10 @@ import scair.ir.*
 abstract class EnumAttrCase[T <: Attribute](
     val symbol: String,
     val typ: T
-) extends ParametrizedAttribute(symbol, Seq(typ)) {
+) extends ParametrizedAttribute {
+  override def name: String = symbol
+  override def parameters: Seq[Attribute | Seq[Attribute]] =
+    Seq(typ)
   def parse[$: P]: P[Attribute] = P(symbol.!).map(_ => this)
   override def custom_print = symbol
 }

--- a/core/src/main/scala-3/builtin/EnumAttr.scala
+++ b/core/src/main/scala-3/builtin/EnumAttr.scala
@@ -29,8 +29,10 @@ abstract class EnumAttrCase[T <: Attribute](
     val typ: T
 ) extends ParametrizedAttribute {
   override def name: String = symbol
+
   override def parameters: Seq[Attribute | Seq[Attribute]] =
     Seq(typ)
+
   def parse[$: P]: P[Attribute] = P(symbol.!).map(_ => this)
   override def custom_print = symbol
 }

--- a/core/src/main/scala-3/ir/Attribute.scala
+++ b/core/src/main/scala-3/ir/Attribute.scala
@@ -38,7 +38,7 @@ extension (x: Seq[Attribute] | Attribute)
   }
 
 abstract class ParametrizedAttribute() extends Attribute {
-  
+
   def parameters: Seq[Attribute | Seq[Attribute]]
 
   override def custom_print =

--- a/core/src/main/scala-3/ir/Attribute.scala
+++ b/core/src/main/scala-3/ir/Attribute.scala
@@ -38,9 +38,8 @@ extension (x: Seq[Attribute] | Attribute)
   }
 
 abstract class ParametrizedAttribute() extends Attribute {
-
-  override def name: String
-  def parameters: Seq[Attribute | Seq[Attribute]] = Seq()
+  
+  def parameters: Seq[Attribute | Seq[Attribute]]
 
   override def custom_print =
     s"${prefix}${name}${

--- a/core/src/main/scala-3/ir/Attribute.scala
+++ b/core/src/main/scala-3/ir/Attribute.scala
@@ -37,10 +37,10 @@ extension (x: Seq[Attribute] | Attribute)
     case attr: Attribute => attr.custom_print
   }
 
-abstract class ParametrizedAttribute(
-    override val name: String,
-    val parameters: Seq[Attribute | Seq[Attribute]] = Seq()
-) extends Attribute {
+abstract class ParametrizedAttribute() extends Attribute {
+
+  override def name: String
+  def parameters: Seq[Attribute | Seq[Attribute]] = Seq()
 
   override def custom_print =
     s"${prefix}${name}${

--- a/dialects/src/main/scala-3/cmath/CMath.scala
+++ b/dialects/src/main/scala-3/cmath/CMath.scala
@@ -14,7 +14,7 @@ case class Complex(
 case class Norm(
     in: Operand[Complex],
     res: Result[FloatType]
-) extends DerivedOperation["cmath.norm", Norm] 
+) extends DerivedOperation["cmath.norm", Norm]
     derives DerivedOperationCompanion
 
 case class Mul(

--- a/dialects/src/main/scala-3/cmath/CMath.scala
+++ b/dialects/src/main/scala-3/cmath/CMath.scala
@@ -7,12 +7,8 @@ import scair.ir.*
 
 case class Complex(
     val typ: FloatType | IndexType.type
-) extends ParametrizedAttribute(
-      name = "cmath.complex",
-      parameters = Seq(typ)
-    )
+) extends DerivedAttribute["cmath.complex", Complex]
     with TypeAttribute
-    with MLIRName["cmath.complex"]
     derives DerivedAttributeCompanion
 
 case class Norm(

--- a/dialects/src/main/scala-3/cmath/CMath.scala
+++ b/dialects/src/main/scala-3/cmath/CMath.scala
@@ -14,7 +14,7 @@ case class Complex(
 case class Norm(
     in: Operand[Complex],
     res: Result[FloatType]
-) extends DerivedOperation["cmath.norm", Norm]
+) extends DerivedOperation["cmath.norm", Norm] 
     derives DerivedOperationCompanion
 
 case class Mul(

--- a/dialects/src/main/scala-3/lingodb/DBOps.scala
+++ b/dialects/src/main/scala-3/lingodb/DBOps.scala
@@ -148,7 +148,7 @@ object DB_IntervalType extends AttributeCompanion {
 case class DB_IntervalType(val unit: Attribute)
     extends ParametrizedAttribute
     with TypeAttribute {
-  
+
   override def name: String = "db.interval"
   override def parameters: Seq[Attribute | Seq[Attribute]] = Seq(unit)
 

--- a/dialects/src/main/scala-3/lingodb/DBOps.scala
+++ b/dialects/src/main/scala-3/lingodb/DBOps.scala
@@ -90,11 +90,11 @@ object DB_CharType extends AttributeCompanion {
 }
 
 case class DB_CharType(val typ: Seq[Attribute])
-    extends ParametrizedAttribute(
-      name = "db.char",
-      parameters = typ
-    )
+    extends ParametrizedAttribute
     with TypeAttribute {
+
+  override def name: String = "db.char"
+  override def parameters: Seq[Attribute] = typ
 
   override def custom_verify(): Either[String, Unit] = {
     if (typ.length != 1) {
@@ -127,11 +127,11 @@ object DB_DateType extends AttributeCompanion {
 }
 
 case class DB_DateType(val unit: DB_DateUnit_Case)
-    extends ParametrizedAttribute(
-      name = "db.date",
-      parameters = Seq(unit)
-    )
-    with TypeAttribute
+    extends ParametrizedAttribute
+    with TypeAttribute {
+  override def name: String = "db.date"
+  override def parameters: Seq[Attribute | Seq[Attribute]] = Seq(unit)
+}
 
 // ==------------== //
 //   IntervalType   //
@@ -146,11 +146,11 @@ object DB_IntervalType extends AttributeCompanion {
 }
 
 case class DB_IntervalType(val unit: Attribute)
-    extends ParametrizedAttribute(
-      name = "db.interval",
-      parameters = Seq(unit)
-    )
+    extends ParametrizedAttribute
     with TypeAttribute {
+  
+  override def name: String = "db.interval"
+  override def parameters: Seq[Attribute | Seq[Attribute]] = Seq(unit)
 
   // override def custom_verify(): Unit = {
   //   if (typ.length != 1) {
@@ -183,11 +183,11 @@ object DB_DecimalType extends AttributeCompanion {
 }
 
 case class DB_DecimalType(val typ: Seq[Attribute])
-    extends ParametrizedAttribute(
-      name = "db.decimal",
-      parameters = typ
-    )
+    extends ParametrizedAttribute
     with TypeAttribute {
+
+  override def name: String = "db.decimal"
+  override def parameters: Seq[Attribute | Seq[Attribute]] = typ
 
   override def custom_verify(): Either[String, Unit] = {
     if (typ.length != 2) {
@@ -226,11 +226,11 @@ object DB_StringType extends AttributeCompanion {
 }
 
 case class DB_StringType(val typ: Seq[Attribute])
-    extends ParametrizedAttribute(
-      name = "db.string",
-      parameters = typ
-    )
+    extends ParametrizedAttribute
     with TypeAttribute {
+
+  override def name: String = "db.string"
+  override def parameters: Seq[Attribute | Seq[Attribute]] = typ
 
   override def custom_verify(): Either[String, Unit] = {
     if (typ.length > 1) {

--- a/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
+++ b/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
@@ -118,6 +118,7 @@ case class SortSpecificationAttr(
     val sortSpec: RelAlg_SortSpec_Case
 ) extends ParametrizedAttribute {
   override def name: String = "db.interval"
+  override def parameters: Seq[Attribute | Seq[Attribute]] = Seq(attr, sortSpec)
   override def custom_print = s"(${attr.custom_print},${sortSpec.custom_print})"
 }
 

--- a/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
+++ b/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
@@ -116,9 +116,8 @@ object SortSpecificationAttr extends AttributeCompanion {
 case class SortSpecificationAttr(
     val attr: ColumnRefAttr,
     val sortSpec: RelAlg_SortSpec_Case
-) extends ParametrizedAttribute(
-      name = "db.interval"
-    ) {
+) extends ParametrizedAttribute {
+  override def name: String = "db.interval"
   override def custom_print = s"(${attr.custom_print},${sortSpec.custom_print})"
 }
 

--- a/dialects/src/main/scala-3/lingodb/SubOperatorOps.scala
+++ b/dialects/src/main/scala-3/lingodb/SubOperatorOps.scala
@@ -39,6 +39,7 @@ case class StateMembers(
 ) extends ParametrizedAttribute {
 
   override def name: String = "subop.state_members"
+
   override def parameters: Seq[Attribute | Seq[Attribute]] =
     names :++ types
 
@@ -68,7 +69,7 @@ case class ResultTable(
     val members: StateMembers
 ) extends ParametrizedAttribute
     with TypeAttribute {
-  
+
   override def name: String = "subop.result_table"
   override def parameters: Seq[Attribute | Seq[Attribute]] = Seq(members)
 }

--- a/dialects/src/main/scala-3/lingodb/SubOperatorOps.scala
+++ b/dialects/src/main/scala-3/lingodb/SubOperatorOps.scala
@@ -36,10 +36,11 @@ object StateMembers extends AttributeCompanion {
 case class StateMembers(
     val names: Seq[StringData],
     val types: Seq[Attribute]
-) extends ParametrizedAttribute(
-      name = "subop.state_members",
-      parameters = names :++ types
-    ) {
+) extends ParametrizedAttribute {
+
+  override def name: String = "subop.state_members"
+  override def parameters: Seq[Attribute | Seq[Attribute]] =
+    names :++ types
 
   override def custom_print =
     s"[${(for { (x, y) <- (names zip types) } yield s"${x.stringLiteral} : ${y.custom_print}").mkString(", ")}]"
@@ -65,11 +66,12 @@ object ResultTable extends AttributeCompanion {
 
 case class ResultTable(
     val members: StateMembers
-) extends ParametrizedAttribute(
-      name = "subop.result_table",
-      parameters = Seq(members)
-    )
-    with TypeAttribute
+) extends ParametrizedAttribute
+    with TypeAttribute {
+  
+  override def name: String = "subop.result_table"
+  override def parameters: Seq[Attribute | Seq[Attribute]] = Seq(members)
+}
 
 ////////////////
 // OPERATIONS //

--- a/dialects/src/main/scala-3/lingodb/TupleStream.scala
+++ b/dialects/src/main/scala-3/lingodb/TupleStream.scala
@@ -30,11 +30,11 @@ object TupleStreamTuple extends AttributeCompanion {
 }
 
 case class TupleStreamTuple(val tupleVals: Seq[Attribute])
-    extends ParametrizedAttribute(
-      name = "tuples.tuple",
-      parameters = tupleVals
-    )
+    extends ParametrizedAttribute
     with TypeAttribute {
+
+  override def name: String = "tuples.tuple"
+  override def parameters: Seq[Attribute | Seq[Attribute]] = tupleVals
 
   override def custom_verify(): Either[String, Unit] = {
     if (tupleVals.length != 0 && tupleVals.length != 2) {
@@ -59,11 +59,11 @@ object TupleStream extends AttributeCompanion {
 }
 
 case class TupleStream(val tuples: Seq[Attribute])
-    extends ParametrizedAttribute(
-      name = "tuples.tuplestream",
-      parameters = tuples
-    )
+    extends ParametrizedAttribute
     with TypeAttribute {
+
+  override def name: String = "tuples.tuplestream"
+  override def parameters: Seq[Attribute | Seq[Attribute]] = tuples
 
   override def custom_verify(): Either[String, Unit] = {
 
@@ -106,10 +106,9 @@ object ColumnDefAttr extends AttributeCompanion {
 }
 
 case class ColumnDefAttr(val refName: SymbolRefAttr, val typ: Attribute)
-    extends ParametrizedAttribute(
-      name = "tuples.column_def"
-    ) {
+    extends ParametrizedAttribute {
 
+  override def name: String = "tuples.column_def"
   override def custom_print =
     s"${refName.custom_print}({type = ${typ.custom_print}})"
 
@@ -130,9 +129,8 @@ object ColumnRefAttr extends AttributeCompanion {
 }
 
 case class ColumnRefAttr(val refName: SymbolRefAttr)
-    extends ParametrizedAttribute(
-      name = "tuples.column_ref"
-    ) {
+    extends ParametrizedAttribute {
+  override def name: String = "tuples.column_ref"
   override def custom_print = s"${refName.custom_print}"
 }
 

--- a/dialects/src/main/scala-3/lingodb/TupleStream.scala
+++ b/dialects/src/main/scala-3/lingodb/TupleStream.scala
@@ -109,6 +109,7 @@ case class ColumnDefAttr(val refName: SymbolRefAttr, val typ: Attribute)
     extends ParametrizedAttribute {
 
   override def name: String = "tuples.column_def"
+
   override def custom_print =
     s"${refName.custom_print}({type = ${typ.custom_print}})"
 

--- a/dialects/src/main/scala-3/lingodb/TupleStream.scala
+++ b/dialects/src/main/scala-3/lingodb/TupleStream.scala
@@ -109,6 +109,7 @@ case class ColumnDefAttr(val refName: SymbolRefAttr, val typ: Attribute)
     extends ParametrizedAttribute {
 
   override def name: String = "tuples.column_def"
+  override def parameters: Seq[Attribute | Seq[Attribute]] = Seq(refName, typ)
 
   override def custom_print =
     s"${refName.custom_print}({type = ${typ.custom_print}})"
@@ -132,6 +133,7 @@ object ColumnRefAttr extends AttributeCompanion {
 case class ColumnRefAttr(val refName: SymbolRefAttr)
     extends ParametrizedAttribute {
   override def name: String = "tuples.column_ref"
+  override def parameters: Seq[Attribute | Seq[Attribute]] = Seq(refName)
   override def custom_print = s"${refName.custom_print}"
 }
 

--- a/dialects/src/main/scala-3/llvm/LLVM.scala
+++ b/dialects/src/main/scala-3/llvm/LLVM.scala
@@ -6,13 +6,10 @@ import scair.dialects.builtin.*
 import scair.ir.*
 
 case class Ptr()
-    extends ParametrizedAttribute(
-      name = "llvm.ptr",
-      parameters = Seq()
-    )
+    extends DerivedAttribute["llvm.ptr", Ptr]
     with TypeAttribute
-    with MLIRName["llvm.ptr"] derives DerivedAttributeCompanion
-
+    derives DerivedAttributeCompanion 
+    
 case class Load(
     ptr: Operand[Ptr],
     result: Result[Attribute]

--- a/dialects/src/main/scala-3/llvm/LLVM.scala
+++ b/dialects/src/main/scala-3/llvm/LLVM.scala
@@ -5,11 +5,9 @@ import scair.clair.macros.*
 import scair.dialects.builtin.*
 import scair.ir.*
 
-case class Ptr()
-    extends DerivedAttribute["llvm.ptr", Ptr]
-    with TypeAttribute
-    derives DerivedAttributeCompanion 
-    
+case class Ptr() extends DerivedAttribute["llvm.ptr", Ptr] with TypeAttribute
+    derives DerivedAttributeCompanion
+
 case class Load(
     ptr: Operand[Ptr],
     result: Result[Attribute]


### PR DESCRIPTION
**Changing the ugly:**
```Scala
case class Complex(
    val typ: FloatType | IndexType.type
) extends ParametrizedAttribute(
      name = "cmath.complex",
      parameters = Seq(typ)
    )
    with TypeAttribute
    with MLIRName["cmath.complex"]
    derives DerivedAttributeCompanion
```
**into:**
```Scala
case class Complex(
    val typ: FloatType | IndexType.type
) extends DerivedAttribute["cmath.complex", Complex]
    with TypeAttribute
    derives DerivedAttributeCompanion
```