### PR TITLE
Bump to Scala 3.7.1

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -25,7 +25,7 @@ import java.io.PrintWriter
 trait ScairSettings extends ScalaModule with UnidocModule {
 
   def scoverageVersion = T{"2.3.0"}
-  override def scalaVersion = "3.6.4"
+  override def scalaVersion = "3.7.1"
   override def scalacOptions = super.scalacOptions() ++ Seq("-Wunused:imports")
   override def unidocOptions = super.unidocOptions() ++ Seq("-snippet-compiler:compile")
 

--- a/clair/src/main/scala-3/Macros.scala
+++ b/clair/src/main/scala-3/Macros.scala
@@ -9,7 +9,6 @@ import scair.dialects.builtin.*
 import scair.ir.*
 import scair.scairdl.constraints.*
 
-import scala.collection.mutable
 import scala.quoted.*
 
 // ░█████╗░ ██╗░░░░░ ░█████╗░ ██╗ ██████╗░ ██╗░░░██╗ ██████╗░
@@ -57,7 +56,7 @@ def makeSegmentSizes[T <: MayVariadicOpInputDef: Type](
           defs.map((d) =>
             d.variadicity match {
               case Variadicity.Single => Expr(1)
-              case Variadicity.Variadic =>
+              case Variadicity.Variadic | Variadicity.Optional =>
                 '{
                   ${ selectMember(adtOpExpr, d.name).asExprOf[Seq[?]] }.length
                 }

--- a/clair/test/src/scala-3/MacrosTest.scala
+++ b/clair/test/src/scala-3/MacrosTest.scala
@@ -1,8 +1,6 @@
 import scair.ir.*
 import scair.dialects.builtin.*
 import scair.clair.macros.*
-import scala.quoted.*
-import scair.Printer
 import org.scalatest.*
 import org.scalatest.flatspec.*
 import org.scalatest.matchers.should.Matchers.*

--- a/core/src/main/scala-3/builtin/Builtin.scala
+++ b/core/src/main/scala-3/builtin/Builtin.scala
@@ -10,8 +10,6 @@ import scair.ir.*
 import scair.scairdl.constraints.BaseAttr
 import scair.scairdl.constraints.ConstraintContext
 
-import scala.collection.immutable
-import scala.collection.mutable
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try

--- a/core/src/main/scala-3/builtin/EnumAttr.scala
+++ b/core/src/main/scala-3/builtin/EnumAttr.scala
@@ -55,7 +55,7 @@ abstract class EnumAttr[T <: Attribute](
     //  then "parse("ascc", v(_))"
     //  returns "Success("asc")"
     //  but we need "Success("ascc")"
-    parser(cases.sortBy(_.symbol.length)(Ordering[Int].reverse))
+    parser(cases.sortBy(_.symbol.length)(using Ordering[Int].reverse))
   }
 
 }

--- a/core/src/main/scala-3/ir/Attribute.scala
+++ b/core/src/main/scala-3/ir/Attribute.scala
@@ -2,7 +2,6 @@ package scair.ir
 
 import fastparse.*
 import scair.AttrParser
-import scair.Parser.*
 
 // ██╗ ██████╗░
 // ██║ ██╔══██╗

--- a/core/src/main/scala-3/scairdl/IRElements.scala
+++ b/core/src/main/scala-3/scairdl/IRElements.scala
@@ -142,7 +142,7 @@ import fastparse.*"""
         .mkString("\n", "\n", "\n") +
       { for (hatch <- attrHatches) yield hatch.importt }
         .mkString("", "\n", "\n") +
-      (operations.map(_.print(0)) ++ attributes.map(_.print(0)))
+      (operations.map(_.print(using 0)) ++ attributes.map(_.print(0)))
         .mkString("\n") + s"""
 val ${name}Dialect: Dialect = new Dialect(
   operations = Seq(${(operations.map(_.className) ++ opHatches.map(_.name))
@@ -733,20 +733,20 @@ case class OperationDef(
     }
 
   def constructs_verification(implicit indent: Int): String = s"""
-    ${operands_verification(indent + 1)}
-    ${results_verification(indent + 1)}
-    ${regions_verification(indent + 1)}
-    ${successors_verification(indent + 1)}
+    ${operands_verification(using indent + 1)}
+    ${results_verification(using indent + 1)}
+    ${regions_verification(using indent + 1)}
+    ${successors_verification(using indent + 1)}
 """
 
   def irdl_verification(implicit indent: Int): String = s"""
   override def custom_verify(): Unit = 
     val verification_context = new ConstraintContext()
-    ${constructs_verification(indent + 1)}
-    ${constraints_verification(indent + 1)}
+    ${constructs_verification(using indent + 1)}
+    ${constraints_verification(using indent + 1)}
 """
 
-  def print(implicit indent: Int): String = s"""
+  def print(implicit indent: Int = 0): String = s"""
 object $className extends MLIROperationObject {
   override def name = "$name"
   ${assembly_format
@@ -766,10 +766,10 @@ case class $className(
 ) extends RegisteredOperation(name = "$name", operands, successors, results_types, regions, properties, attributes) {
 
 
-${helpers(indent + 1)}
-${accessors(indent + 1)}
-${print_constr_defs(indent + 1)}
-${irdl_verification(indent + 1)}
+${helpers(using indent + 1)}
+${accessors(using indent + 1)}
+${print_constr_defs(using indent + 1)}
+${irdl_verification(using indent + 1)}
 
 }
 """

--- a/core/test/src/scala-3/AttrParserTest.scala
+++ b/core/test/src/scala-3/AttrParserTest.scala
@@ -4,7 +4,6 @@ import fastparse.*
 import org.scalatest.*
 import org.scalatest.flatspec.*
 import org.scalatest.matchers.should.Matchers.*
-import org.scalatest.prop.*
 import org.scalatest.prop.TableDrivenPropertyChecks.forAll
 import org.scalatest.prop.Tables.Table
 import scair.dialects.builtin.*

--- a/core/test/src/scala-3/ParserTest.scala
+++ b/core/test/src/scala-3/ParserTest.scala
@@ -5,7 +5,6 @@ import org.scalatest.*
 import org.scalatest.flatspec.*
 import org.scalatest.matchers.should.Matchers.*
 import org.scalatest.prop.*
-import org.scalatest.prop.Tables.*
 import scair.dialects.builtin.*
 import scair.ir.*
 

--- a/core/test/src/scala-3/TraitTest.scala
+++ b/core/test/src/scala-3/TraitTest.scala
@@ -3,10 +3,7 @@ package scair
 import org.scalatest.*
 import org.scalatest.flatspec.*
 import org.scalatest.matchers.should.Matchers.*
-import scair.Parser.*
 import scair.ir.*
-
-import scala.collection.mutable
 
 object FillerOp extends OperationCompanion {
   override def name: String = "filler"

--- a/core/test/src/scala-3/builtin/Conversion.scala
+++ b/core/test/src/scala-3/builtin/Conversion.scala
@@ -1,9 +1,6 @@
 package scair
 
-import scair.core.macros.TransparentData
-
 import scair.dialects.builtin._
-import org.scalatest.*
 import org.scalatest.flatspec.*
 import org.scalatest.matchers.should.Matchers.*
 

--- a/core/test/src/scala-3/ir/Block.scala
+++ b/core/test/src/scala-3/ir/Block.scala
@@ -3,12 +3,10 @@ package scair.ir
 import org.scalatest.*
 import org.scalatest.flatspec.*
 import org.scalatest.matchers.should.Matchers.*
-import org.scalatest.prop.*
 import org.scalatest.prop.TableDrivenPropertyChecks.forAll
 import org.scalatest.prop.Tables.Table
 import scair.Printer
 import scair.dialects.builtin.I32
-import scair.dialects.builtin.IntegerType
 import java.io.StringWriter
 import java.io.PrintWriter
 

--- a/dialects/src/main/scala-3/lingodb/DBOps.scala
+++ b/dialects/src/main/scala-3/lingodb/DBOps.scala
@@ -10,8 +10,6 @@ import scair.Printer
 import scair.dialects.builtin.*
 import scair.ir.*
 
-import scala.collection.immutable
-import scala.collection.mutable
 import scala.math.max
 
 // ==---== //

--- a/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
+++ b/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
@@ -16,9 +16,6 @@ import scair.dialects.LingoDB.TupleStream.*
 import scair.dialects.builtin.*
 import scair.ir.*
 
-import scala.collection.immutable
-import scala.collection.mutable
-
 // ==---== //
 //  Enums
 // ==---== //

--- a/dialects/src/main/scala-3/lingodb/SubOperatorOps.scala
+++ b/dialects/src/main/scala-3/lingodb/SubOperatorOps.scala
@@ -9,9 +9,6 @@ import scair.Parser.whitespace
 import scair.dialects.builtin.*
 import scair.ir.*
 
-import scala.collection.immutable
-import scala.collection.mutable
-
 ////////////////
 // ATTRIBUTES //
 ////////////////

--- a/dialects/src/main/scala-3/lingodb/TupleStream.scala
+++ b/dialects/src/main/scala-3/lingodb/TupleStream.scala
@@ -9,9 +9,6 @@ import scair.Parser.whitespace
 import scair.dialects.builtin.*
 import scair.ir.*
 
-import scala.collection.immutable
-import scala.collection.mutable
-
 ///////////
 // TYPES //
 ///////////

--- a/dialects/src/main/scala-3/math/Math.scala
+++ b/dialects/src/main/scala-3/math/Math.scala
@@ -5,8 +5,6 @@ import scair.Parser
 import scair.Parser.whitespace
 import scair.ir.*
 
-import scala.collection.mutable
-
 ////////////////
 // OPERATIONS //
 ////////////////

--- a/dialects/test/src/scala-3/ArithTest.scala
+++ b/dialects/test/src/scala-3/ArithTest.scala
@@ -3,7 +3,6 @@ package scair
 import scair.ir.*
 import scair.dialects.arith.*
 import scair.dialects.builtin.*
-import scair.dialects.test.*
 import scair.dialects.func.*
 import scair.Printer
 

--- a/dialects/test/src/scala-3/TupleStreamTest.scala
+++ b/dialects/test/src/scala-3/TupleStreamTest.scala
@@ -4,7 +4,6 @@ import fastparse.*
 import org.scalatest.*
 import org.scalatest.flatspec.*
 import org.scalatest.matchers.should.Matchers.*
-import org.scalatest.prop.*
 import org.scalatest.prop.TableDrivenPropertyChecks.forAll
 import org.scalatest.prop.Tables.Table
 import scair.dialects.LingoDB.TupleStream.*


### PR DESCRIPTION
- 3.7: https://www.scala-lang.org/news/3.7.0/
- 3.7.1: https://github.com/scala/scala3/releases/tag/3.7.1

