### PR TITLE
Bump Scalafmt to 3.9.7

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.7.15"
+version = "3.9.7"
 runner.dialect = scala3
 newlines.topLevelStatementBlankLines = [
   { blanks = 1 }

--- a/clair/src/main/scala-3/Macros.scala
+++ b/clair/src/main/scala-3/Macros.scala
@@ -55,7 +55,7 @@ def makeSegmentSizes[T <: MayVariadicOpInputDef: Type](
         Expr.ofList(
           defs.map((d) =>
             d.variadicity match {
-              case Variadicity.Single => Expr(1)
+              case Variadicity.Single                          => Expr(1)
               case Variadicity.Variadic | Variadicity.Optional =>
                 '{
                   ${ selectMember(adtOpExpr, d.name).asExprOf[Seq[?]] }.length
@@ -304,7 +304,7 @@ def expectSegmentSizes[Def <: OpInputDef: Type](
         case Some(segmentSizes) =>
           segmentSizes match
             case dense: DenseArrayAttr => dense
-            case _ =>
+            case _                     =>
               throw new Exception(
                 s"Expected ${${ Expr(segmentSizesName) }} to be a DenseArrayAttr"
               )
@@ -333,7 +333,7 @@ def expectSegmentSizes[Def <: OpInputDef: Type](
 
     for (s <- dense) yield s match {
       case right: IntegerAttr => right.value.data.toInt
-      case _ =>
+      case _                  =>
         throw new Exception(
           "Unreachable exception as per above constraint check."
         )
@@ -492,9 +492,10 @@ def verifiedConstructs[Def <: OpInputDef: Type](
           case Variadicity.Variadic =>
             '{
               if (
-                !${ c }
-                  .isInstanceOf[Seq[DefinedInputOf[Def, t & Attribute]]]
-              ) then
+                  !${ c }
+                    .isInstanceOf[Seq[DefinedInputOf[Def, t & Attribute]]]
+                )
+              then
                 throw new Exception(
                   s"Expected ${${ Expr(d.name) }} to be of type ${${
                       Expr(Type.show[Seq[DefinedInputOf[Def, t & Attribute]]])

--- a/clair/src/main/scala-3/package.scala
+++ b/clair/src/main/scala-3/package.scala
@@ -42,8 +42,7 @@ package scair
   * case class SampleType(
   *     val value: FloatType
   * ) extends DerivedAttribute["sample.sample_type", SampleType]
-  *     with TypeAttribute
-  *     derives DerivedAttributeCompanion
+  *     with TypeAttribute derives DerivedAttributeCompanion
   *
   * /*≡≡=---=≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡=---=≡≡*\
   * ||   defining custom operations   ||

--- a/clair/test/src/scala-3/MacrosTest.scala
+++ b/clair/test/src/scala-3/MacrosTest.scala
@@ -16,8 +16,7 @@ case class Mul(
     rhs: Operand[IntegerType],
     result: Result[IntegerType],
     randProp: StringData
-) extends DerivedOperation["cmath.mul", Mul]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["cmath.mul", Mul] derives DerivedOperationCompanion
 
 case class MulSingleVariadic(
     lhs: Operand[IntegerType],

--- a/core/src/main/scala-3/Parser.scala
+++ b/core/src/main/scala-3/Parser.scala
@@ -256,7 +256,7 @@ object Parser {
       if (valueWaitlist.size > 0) {
         parentScope match {
           case Some(x) => x.valueWaitlist ++= valueWaitlist
-          case None =>
+          case None    =>
             val opName = valueWaitlist.head._1.name
             val operandName = valueWaitlist.head._2(0)._1
             val operandTyp = valueWaitlist.head._2(0)._2
@@ -324,7 +324,7 @@ object Parser {
       if (blockWaitlist.size > 0) {
         parentScope match {
           case Some(x) => x.blockWaitlist ++= blockWaitlist
-          case None =>
+          case None    =>
             throw new Exception(
               s"Successor ^${blockWaitlist.head._2.head} not defined within Scope"
             )
@@ -628,7 +628,7 @@ class Parser(val context: MLContext, val args: Args = Args())
   ).map((toplevel: Seq[Operation]) =>
     toplevel.toList match {
       case (head: ModuleOp) :: Nil => head
-      case _ =>
+      case _                       =>
         val block = new Block(operations = toplevel)
         val region = new Region(blocks = Seq(block))
         val moduleOp = new ModuleOp(regions = Seq(region))

--- a/core/src/main/scala-3/Printer.scala
+++ b/core/src/main/scala-3/Printer.scala
@@ -30,7 +30,7 @@ case class Printer(
 
   def assignValueName(value: Value[? <: Attribute]): String =
     val name = valueNameMap.contains(value) match {
-      case true => valueNameMap(value)
+      case true  => valueNameMap(value)
       case false =>
         val name = valueNextID.toString
         valueNextID = valueNextID + 1
@@ -91,10 +91,9 @@ case class Printer(
       indentLevel: Int
   ): Unit = {
     things.foreach(_ match
-      case p: Printable => print(p)
+      case p: Printable           => print(p)
       case i: Iterable[Printable] =>
-        printList(i)
-    )
+        printList(i))
   }
 
   inline def printList[T <: Printable](

--- a/core/src/main/scala-3/builtin/AttrParser.scala
+++ b/core/src/main/scala-3/builtin/AttrParser.scala
@@ -128,7 +128,7 @@ class AttrParser(val ctx: MLContext) {
               yy.get match
                 case i: IntegerType => i
                 case i: IndexType   => i
-                case _ =>
+                case _              =>
                   throw new Exception(
                     s"Unreachable, fastparse's | is simply weakly typed."
                   )

--- a/core/src/main/scala-3/ir/Attribute.scala
+++ b/core/src/main/scala-3/ir/Attribute.scala
@@ -42,7 +42,8 @@ abstract class ParametrizedAttribute() extends Attribute {
 
   override def custom_print =
     s"${prefix}${name}${
-        if parameters.size > 0 then parameters.map(x => x.custom_print).mkString("<", ", ", ">")
+        if parameters.size > 0
+        then parameters.map(x => x.custom_print).mkString("<", ", ", ">")
         else ""
       }"
 

--- a/core/src/main/scala-3/ir/Block.scala
+++ b/core/src/main/scala-3/ir/Block.scala
@@ -75,7 +75,7 @@ case class Block private (
         case multiple: Iterable[_] => multiple.asInstanceOf[Iterable[Attribute]]
       }).map(Value(_))),
       ListType.from((operations match {
-        case single: Operation => Seq(single)
+        case single: Operation     => Seq(single)
         case multiple: Iterable[_] =>
           multiple.asInstanceOf[Iterable[Operation]]
       }))
@@ -97,11 +97,11 @@ case class Block private (
     this(
       ListType.from(args._1 match {
         case single: Value[Attribute] => Seq(single)
-        case multiple: Iterable[_] =>
+        case multiple: Iterable[_]    =>
           multiple.asInstanceOf[Iterable[Value[Attribute]]]
       }),
       ListType.from(args._2 match {
-        case single: Operation => Seq(single)
+        case single: Operation     => Seq(single)
         case multiple: Iterable[_] =>
           multiple.asInstanceOf[Iterable[Operation]]
       })

--- a/core/src/main/scala-3/ir/IRUtils.scala
+++ b/core/src/main/scala-3/ir/IRUtils.scala
@@ -48,7 +48,7 @@ extension (dt: DictType[String, Attribute]) {
   ): Attribute = {
     dt.get(key) match {
       case Some(b) => b
-      case None =>
+      case None    =>
         throw new Exception(
           s"Operation '${op_name}' must include an attribute named '${key}' of type '${}'"
         )

--- a/core/src/main/scala-3/scairdl/Constraints.scala
+++ b/core/src/main/scala-3/scairdl/Constraints.scala
@@ -217,7 +217,7 @@ case class BaseAttr[T <: Attribute: ClassTag]() extends IRDLConstraint {
 
     that_attr match {
       case _: T =>
-      case _ =>
+      case _    =>
         val className = implicitly[ClassTag[T]].runtimeClass.getName
         val errstr =
           s"${that_attr.name}'s class does not equal ${className}\n"
@@ -368,7 +368,7 @@ case class ParametrizedAttrConstraint[T <: Attribute: ClassTag](
             for ((p, c) <- x.parameters zip constraints)
               p match {
                 case p: Attribute => c.verify(p, constraint_ctx)
-                case p: Seq[_] =>
+                case p: Seq[_]    =>
                   c.verify(p.asInstanceOf[Seq[Attribute]], constraint_ctx)
               }
 

--- a/core/src/main/scala-3/scairdl/IRElements.scala
+++ b/core/src/main/scala-3/scairdl/IRElements.scala
@@ -423,12 +423,12 @@ case class OperationDef(
               s"operands.length - ${operands.length - variadic_index - 1}"
             ))) ++
           (for (
-            (odef, i) <- operands.zipWithIndex
-              .slice(
-                variadic_index + 1,
-                operands.length
-              )
-          )
+              (odef, i) <- operands.zipWithIndex
+                .slice(
+                  variadic_index + 1,
+                  operands.length
+                )
+            )
             yield single_operand_accessor(
               odef.id,
               s"operands.length - ${operands.length - i}"
@@ -495,12 +495,12 @@ case class OperationDef(
               s"results.length - ${results.length - variadic_index - 1}"
             ))) ++
           (for (
-            (odef, i) <- results.zipWithIndex
-              .slice(
-                variadic_index + 1,
-                results.length
-              )
-          )
+              (odef, i) <- results.zipWithIndex
+                .slice(
+                  variadic_index + 1,
+                  results.length
+                )
+            )
             yield single_result_accessor(
               odef.id,
               s"results.length - ${results.length - i}"
@@ -558,12 +558,12 @@ case class OperationDef(
               s"regions.length - ${regions.length - variadic_index - 1}"
             ))) ++
           (for (
-            (odef, i) <- regions.zipWithIndex
-              .slice(
-                variadic_index + 1,
-                regions.length
-              )
-          )
+              (odef, i) <- regions.zipWithIndex
+                .slice(
+                  variadic_index + 1,
+                  regions.length
+                )
+            )
             yield single_region_accessor(
               odef.id,
               s"regions.length - ${regions.length - i}"
@@ -620,12 +620,12 @@ case class OperationDef(
               s"successors.length - ${successors.length - variadic_index - 1}"
             ))) ++
           (for (
-            (odef, i) <- successors.zipWithIndex
-              .slice(
-                variadic_index + 1,
-                successors.length
-              )
-          )
+              (odef, i) <- successors.zipWithIndex
+                .slice(
+                  variadic_index + 1,
+                  successors.length
+                )
+            )
             yield single_successor_accessor(
               odef.id,
               s"successors.length - ${successors.length - i}"
@@ -679,10 +679,10 @@ case class OperationDef(
         s"""val operandSegmentSizesSum = operandSegmentSizes.fold(0)(_ + _)
     if (operandSegmentSizesSum != operands.length) then throw new Exception(s"Expected $${operandSegmentSizesSum} operands, got $${operands.length}")\n""" +
           (for (
-            (odef, i) <- operands.zipWithIndex.filter(
-              _._1.variadicity == Variadicity.Single
+              (odef, i) <- operands.zipWithIndex.filter(
+                _._1.variadicity == Variadicity.Single
+              )
             )
-          )
             yield s"""    if operandSegmentSizes($i) != 1 then throw new Exception(s"operand segment size expected to be 1 for singular operand ${odef.id} at index $i, got $${operandSegmentSizes($i)}")""")
             .mkString("\n")
 
@@ -700,10 +700,10 @@ case class OperationDef(
         s"""val resultSegmentSizesSum = resultSegmentSizes.fold(0)(_ + _)
     if (resultSegmentSizesSum != results.length) then throw new Exception(s"Expected $${resultSegmentSizesSum} results, got $${results.length}")\n""" +
           (for (
-            (odef, i) <- results.zipWithIndex.filter(
-              _._1.variadicity == Variadicity.Single
+              (odef, i) <- results.zipWithIndex.filter(
+                _._1.variadicity == Variadicity.Single
+              )
             )
-          )
             yield s"""    if resultSegmentSizes($i) != 1 then throw new Exception(s"result segment size expected to be 1 for singular result ${odef.id} at index $i, got $${resultSegmentSizes($i)}")""")
             .mkString("\n")
 

--- a/core/src/main/scala-3/transformations/PatternRewriter.scala
+++ b/core/src/main/scala-3/transformations/PatternRewriter.scala
@@ -48,7 +48,7 @@ object InsertPoint {
         val block = op.container_block.get
         val opIdx = block.getIndexOf(op)
         (opIdx == block.operations.length - 1) match {
-          case true => new InsertPoint(block)
+          case true  => new InsertPoint(block)
           case false =>
             InsertPoint(block, Some(block.operations(opIdx + 1)))
         }
@@ -160,7 +160,7 @@ trait Rewriter {
 
     val block = op.container_block match {
       case Some(x) => x
-      case None =>
+      case None    =>
         throw new Exception("Cannot replace an operation without a parent")
     }
 
@@ -171,7 +171,7 @@ trait Rewriter {
 
     val results = new_results match {
       case Some(x) => x
-      case None =>
+      case None    =>
         if (ops.length == 0) then ListType() else ops.last.results
     }
 
@@ -241,7 +241,7 @@ case class GreedyRewritePatternApplier(patterns: Seq[RewritePattern])
       patterns: Seq[RewritePattern]
   ): Unit = {
     patterns match
-      case Nil => ()
+      case Nil    => ()
       case h :: t =>
         h.match_and_rewrite(op, rewriter)
         if !rewriter.has_done_action then match_and_rewrite_rec(op, rewriter, t)

--- a/core/test/src/scala-3/transformations/PatternRewriter.scala
+++ b/core/test/src/scala-3/transformations/PatternRewriter.scala
@@ -32,8 +32,7 @@ class PatternRewriterTest extends AnyFlatSpec {
       ): Unit =
         val newRes = op.results.map(_ match
           case Result(I32) => Result(I64)
-          case r           => r
-        )
+          case r           => r)
         if newRes != op.results then
           rewriter.replace_op(op, op.updated(results = newRes))
     }

--- a/dialects/src/main/scala-3/affine/Affine.scala
+++ b/dialects/src/main/scala-3/affine/Affine.scala
@@ -43,8 +43,7 @@ case class For(
     upperBoundMap: AffineMapAttr,
     step: IntegerAttr,
     body: Region
-) extends DerivedOperation["affine.for", For]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["affine.for", For] derives DerivedOperationCompanion
 
 /*≡==---==≡≡≡≡≡==---=≡≡*\
 ||     PARALLEL OP     ||
@@ -73,8 +72,7 @@ case class If(
     condition: AffineSetAttr,
     then_region: Region,
     else_region: Region
-) extends DerivedOperation["affine.if", If]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["affine.if", If] derives DerivedOperationCompanion
 
 /*≡==--=≡≡≡≡=--=≡≡*\
 ||    STORE OP    ||
@@ -108,8 +106,7 @@ case class Min(
     arguments: Seq[Operand[IndexType]],
     result: Result[IndexType],
     map: AffineMapAttr
-) extends DerivedOperation["affine.min", Min]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["affine.min", Min] derives DerivedOperationCompanion
 
 /*≡==--=≡≡≡≡=--=≡≡*\
 ||    YIELD OP    ||

--- a/dialects/src/main/scala-3/arith/Arith.scala
+++ b/dialects/src/main/scala-3/arith/Arith.scala
@@ -121,8 +121,7 @@ case class Addf(
     result: Result[FloatType],
     fastmath: FastMathFlagsAttr
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends DerivedOperation["arith.addf", Addf]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["arith.addf", Addf] derives DerivedOperationCompanion
 
 case class Mulf(
     lhs: Operand[FloatType],
@@ -130,8 +129,7 @@ case class Mulf(
     result: Result[FloatType],
     fastmath: FastMathFlagsAttr
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends DerivedOperation["arith.mulf", Mulf]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["arith.mulf", Mulf] derives DerivedOperationCompanion
 
 // I'm not sure about the flag here
 case class Divf(
@@ -140,8 +138,7 @@ case class Divf(
     result: Result[FloatType],
     fastmath: FastMathFlagsAttr
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends DerivedOperation["arith.divf", Divf]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["arith.divf", Divf] derives DerivedOperationCompanion
 
 // TODO Apparently there's a new overflow flag here, overlooking for now.
 case class Addi(
@@ -149,24 +146,21 @@ case class Addi(
     rhs: Operand[AnyIntegerType],
     result: Result[AnyIntegerType]
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends DerivedOperation["arith.addi", Addi]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["arith.addi", Addi] derives DerivedOperationCompanion
 
 case class Subi(
     lhs: Operand[AnyIntegerType],
     rhs: Operand[AnyIntegerType],
     result: Result[AnyIntegerType]
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends DerivedOperation["arith.subi", Subi]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["arith.subi", Subi] derives DerivedOperationCompanion
 
 case class Muli(
     lhs: Operand[AnyIntegerType],
     rhs: Operand[AnyIntegerType],
     result: Result[AnyIntegerType]
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends DerivedOperation["arith.muli", Muli]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["arith.muli", Muli] derives DerivedOperationCompanion
 
 case class Divui(
     lhs: Operand[AnyIntegerType],
@@ -206,24 +200,21 @@ case class Cmpi(
     result: Result[I1],
     predicate: IntegerPredicate
     // assembly_format: "$predicate `,` $lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends DerivedOperation["arith.cmpi", Cmpi]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["arith.cmpi", Cmpi] derives DerivedOperationCompanion
 
 case class Andi(
     lhs: Operand[AnyIntegerType],
     rhs: Operand[AnyIntegerType],
     result: Result[I1]
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends DerivedOperation["arith.andi", Andi]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["arith.andi", Andi] derives DerivedOperationCompanion
 
 case class Ori(
     lhs: Operand[AnyIntegerType],
     rhs: Operand[AnyIntegerType],
     result: Result[I1]
     // assembly_format: "$lhs `,` $rhs `:` type($lhs) `,` type($rhs) `,` type($result)"
-) extends DerivedOperation["arith.ori", Ori]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["arith.ori", Ori] derives DerivedOperationCompanion
 
 case class Sitofp(
     in: Operand[AnyIntegerType],

--- a/dialects/src/main/scala-3/cmath/CMath.scala
+++ b/dialects/src/main/scala-3/cmath/CMath.scala
@@ -8,20 +8,17 @@ import scair.ir.*
 case class Complex(
     val typ: FloatType | IndexType
 ) extends DerivedAttribute["cmath.complex", Complex]
-    with TypeAttribute
-    derives DerivedAttributeCompanion
+    with TypeAttribute derives DerivedAttributeCompanion
 
 case class Norm(
     in: Operand[Complex],
     res: Result[FloatType]
-) extends DerivedOperation["cmath.norm", Norm]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["cmath.norm", Norm] derives DerivedOperationCompanion
 
 case class Mul(
     lhs: Operand[Complex],
     rhs: Operand[Complex],
     res: Result[Complex]
-) extends DerivedOperation["cmath.mul", Mul]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["cmath.mul", Mul] derives DerivedOperationCompanion
 
 val CMathDialect = summonDialect[Tuple1[Complex], (Norm, Mul)](Seq())

--- a/dialects/src/main/scala-3/func/Func.scala
+++ b/dialects/src/main/scala-3/func/Func.scala
@@ -9,16 +9,14 @@ case class Call(
     callee: SymbolRefAttr,
     _operands: Seq[Operand[Attribute]],
     _results: Seq[Result[Attribute]]
-) extends DerivedOperation["func.call", Call]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["func.call", Call] derives DerivedOperationCompanion
 
 case class Func(
     sym_name: StringData,
     function_type: FunctionType,
     sym_visibility: Option[StringData],
     body: Region
-) extends DerivedOperation["func.func", Func]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["func.func", Func] derives DerivedOperationCompanion
 
 case class Return(
     _operands: Seq[Operand[Attribute]]

--- a/dialects/src/main/scala-3/lingodb/DBOps.scala
+++ b/dialects/src/main/scala-3/lingodb/DBOps.scala
@@ -193,12 +193,12 @@ case class DB_DecimalType(val typ: Seq[Attribute])
     } else {
       typ(0) match {
         case _: IntData => Right(())
-        case _ =>
+        case _          =>
           Left("DB_DecimalType type must be (IntData, IntData)")
       }
       typ(1) match {
         case _: IntData => Right(())
-        case _ =>
+        case _          =>
           Left("DB_DecimalType type must be (IntData, IntData)")
       }
     }
@@ -238,7 +238,7 @@ case class DB_StringType(val typ: Seq[Attribute])
     } else if (typ.length == 1)
       typ(0) match {
         case _: StringData => Right(())
-        case _ =>
+        case _             =>
           Left("DB_DecimalType type must be StringData")
       }
     else Right(())
@@ -309,7 +309,7 @@ case class DB_ConstantOp(
     properties.size
   ) match {
     case (0, 0, 1, 0, 0) => Right(this)
-    case _ =>
+    case _               =>
       Left(
         "DB_ConstantOp Operation must contain only 2 dictionary attributes."
       )
@@ -384,7 +384,7 @@ case class DB_CmpOp(
   ) match {
     case (2, 0, 0, 0, 0) =>
       (operands(0).typ == operands(1).typ) match {
-        case true => Right(this)
+        case true  => Right(this)
         case false =>
           Left(
             "In order to be compared, operands' types must match!"
@@ -424,8 +424,8 @@ object DB_MulOp extends OperationCompanion {
     (opLeft.getClass == opRight.getClass) match {
       case true =>
         opLeft match {
-          case x: IntegerAttr => Seq(opLeft)
-          case y: FloatAttr   => Seq(opLeft)
+          case x: IntegerAttr    => Seq(opLeft)
+          case y: FloatAttr      => Seq(opLeft)
           case z: DB_DecimalType =>
             Seq(
               DB_DecimalType(
@@ -528,7 +528,7 @@ case class DB_MulOp(
   ) match {
     case (2, 0, 1, 0, 0) =>
       (operands(0).typ == operands(1).typ) match {
-        case true => Right(this)
+        case true  => Right(this)
         case false =>
           Left(
             "In order to be multiplied, operands' types must match!"
@@ -567,8 +567,8 @@ object DB_DivOp extends OperationCompanion {
     (opLeft.getClass == opRight.getClass) match {
       case true =>
         opLeft match {
-          case x: IntegerAttr => Seq(opLeft)
-          case y: FloatAttr   => Seq(opLeft)
+          case x: IntegerAttr    => Seq(opLeft)
+          case y: FloatAttr      => Seq(opLeft)
           case z: DB_DecimalType =>
             val opLeft0 =
               opLeft
@@ -674,7 +674,7 @@ case class DB_DivOp(
   ) match {
     case (2, 0, 1, 0, 0) =>
       (operands(0).typ == operands(1).typ) match {
-        case true => Right(this)
+        case true  => Right(this)
         case false =>
           Left(
             "In order to be divided, operands' types must match!"
@@ -760,7 +760,7 @@ case class DB_AddOp(
   ) match {
     case (2, 0, 1, 0, 0) =>
       (operands(0).typ == operands(1).typ) match {
-        case true => Right(this)
+        case true  => Right(this)
         case false =>
           Left(
             "In order to be added, operands' types must match!"
@@ -848,7 +848,7 @@ case class DB_SubOp(
   ) match {
     case (2, 0, 1, 0, 0) =>
       (operands(0).typ == operands(1).typ) match {
-        case true => Right(this)
+        case true  => Right(this)
         case false =>
           Left(
             "In order to carry out substitution, operands' types must match!"
@@ -932,7 +932,7 @@ case class CastOp(
     properties.size
   ) match {
     case (1, 0, 1, 0, 0) => Right(this)
-    case _ =>
+    case _               =>
       Left(
         "CastOp Operation must contain only 1 operand and result."
       )

--- a/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
+++ b/dialects/src/main/scala-3/lingodb/RelAlgOps.scala
@@ -206,7 +206,7 @@ case class BaseTableOp(
       {
         results(0).typ match {
           case _: TupleStream => Right(this)
-          case _ =>
+          case _              =>
             Left(
               "BaseTableOp Operation must contain only 1 result."
             )
@@ -216,7 +216,7 @@ case class BaseTableOp(
           case Some(x) =>
             x match {
               case _: StringData => Right(this)
-              case _ =>
+              case _             =>
                 Left(
                   "BaseTableOp Operation must contain a StringAttr named 'table_identifier'."
                 )
@@ -292,7 +292,7 @@ case class SelectionOp(
       {
         operands(0).typ match {
           case _: TupleStream => Right(this)
-          case _ =>
+          case _              =>
             Left(
               "SelectionOp Operation must contain only 1 operand of type TupleStream."
             )
@@ -300,7 +300,7 @@ case class SelectionOp(
       }.flatMap(_ => {
         results(0).typ match {
           case _: TupleStream => Right(this)
-          case _ =>
+          case _              =>
             Left(
               "SelectionOp Operation must contain only 1 result of type TupleStream."
             )
@@ -374,7 +374,7 @@ case class MapOp(
       {
         operands(0).typ match {
           case _: TupleStream => Right(this)
-          case _ =>
+          case _              =>
             Left(
               "MapOp Operation must contain only 1 operand of type TupleStream."
             )
@@ -382,7 +382,7 @@ case class MapOp(
       }.flatMap(_ => {
         results(0).typ match {
           case _: TupleStream => Right(this)
-          case _ =>
+          case _              =>
             Left(
               "MapOp Operation must contain only 1 result of type TupleStream."
             )
@@ -392,7 +392,7 @@ case class MapOp(
           case Some(x) =>
             x match {
               case _: ArrayAttribute[_] => Right(this)
-              case _ =>
+              case _                    =>
                 Left(
                   "MapOp Operation must contain a ArrayAttribute named 'computed_cols'."
                 )
@@ -483,14 +483,14 @@ case class AggregationOp(
       {
         operands(0).typ match {
           case _: TupleStream => Right(this)
-          case _ =>
+          case _              =>
             Left(
               "AggregationOp Operation must contain only 1 operand of type TupleStream."
             )
         }
         results(0).typ match {
           case _: TupleStream => Right(this)
-          case _ =>
+          case _              =>
             Left(
               "AggregationOp Operation must contain only 1 result of type TupleStream."
             )
@@ -500,7 +500,7 @@ case class AggregationOp(
           case Some(x) =>
             x match {
               case _: ArrayAttribute[_] => Right(this)
-              case _ =>
+              case _                    =>
                 Left(
                   "AggregationOp Operation must contain an ArrayAttribute named 'computed_cols'."
                 )
@@ -515,7 +515,7 @@ case class AggregationOp(
           case Some(x) =>
             x match {
               case _: ArrayAttribute[_] => Right(this)
-              case _ =>
+              case _                    =>
                 Left(
                   "AggregationOp Operation must contain an ArrayAttribute named 'group_by_cols'."
                 )
@@ -591,7 +591,7 @@ case class CountRowsOp(
       {
         operands(0).typ match {
           case _: TupleStream => Right(this)
-          case _ =>
+          case _              =>
             Left(
               "CountRowsOp Operation must contain 1 operand of type TupleStream."
             )
@@ -599,7 +599,7 @@ case class CountRowsOp(
       }.flatMap(_ => {
         results(0).typ match {
           case _: IntegerType => Right(this)
-          case _ =>
+          case _              =>
             Left(
               "CountRowsOp Operation must contain only 1 result of IntegerType."
             )
@@ -675,7 +675,7 @@ case class AggrFuncOp(
       {
         operands(0).typ match {
           case _: TupleStream => Right(this)
-          case _ =>
+          case _              =>
             Left(
               "AggrFuncOp Operation must contain 1 operand of type TupleStream."
             )
@@ -685,7 +685,7 @@ case class AggrFuncOp(
           case Some(x) =>
             x match {
               case _: RelAlg_AggrFunc_Case => Right(this)
-              case _ =>
+              case _                       =>
                 Left(
                   "AggrFuncOp Operation must contain an RelAlg_AggrFunc enum named 'fn'."
                 )
@@ -700,7 +700,7 @@ case class AggrFuncOp(
           case Some(x) =>
             x match {
               case _: ColumnRefAttr => Right(this)
-              case _ =>
+              case _                =>
                 Left(
                   "AggrFuncOp Operation must contain an ColumnRefAttr named 'attr'."
                 )
@@ -782,7 +782,7 @@ case class SortOp(
       {
         operands(0).typ match {
           case _: TupleStream => Right(this)
-          case _ =>
+          case _              =>
             Left(
               "SortOp Operation must contain 1 operand of type TupleStream."
             )
@@ -790,7 +790,7 @@ case class SortOp(
       }.flatMap(_ => {
         results(0).typ match {
           case _: TupleStream => Right(this)
-          case _ =>
+          case _              =>
             Left(
               "SortOp Operation must contain 1 operand of type TupleStream."
             )
@@ -800,7 +800,7 @@ case class SortOp(
           case Some(x) =>
             x match {
               case _: ArrayAttribute[_] => Right(this)
-              case _ =>
+              case _                    =>
                 Left(
                   "SortOp Operation must contain an ArrayAttribute enum named 'sortspecs'."
                 )
@@ -888,7 +888,7 @@ case class MaterializeOp(
       {
         operands(0).typ match {
           case _: TupleStream => Right(this)
-          case _ =>
+          case _              =>
             Left(
               "MaterializeOp Operation must contain 1 operand of type TupleStream."
             )
@@ -896,7 +896,7 @@ case class MaterializeOp(
       }.flatMap(_ => {
         results(0).typ match {
           case _: ResultTable => Right(this)
-          case _ =>
+          case _              =>
             Left(
               "MaterializeOp Operation must contain 1 operand of type ResultOp."
             )
@@ -906,7 +906,7 @@ case class MaterializeOp(
           case Some(x) =>
             x match {
               case _: ArrayAttribute[_] => Right(this)
-              case _ =>
+              case _                    =>
                 Left(
                   "MaterializeOp Operation must contain an ArrayAttribute enum named 'cols'."
                 )
@@ -921,7 +921,7 @@ case class MaterializeOp(
           case Some(x) =>
             x match {
               case _: ArrayAttribute[_] => Right(this)
-              case _ =>
+              case _                    =>
                 Left(
                   "MaterializeOp Operation must contain an ArrayAttribute named 'columns'."
                 )

--- a/dialects/src/main/scala-3/lingodb/SubOperatorOps.scala
+++ b/dialects/src/main/scala-3/lingodb/SubOperatorOps.scala
@@ -135,7 +135,7 @@ case class SetResultOp(
         case Some(x) =>
           x match {
             case _: IntegerAttr => Right(this)
-            case _ =>
+            case _              =>
               Left(
                 "SetResultOp Operation's 'result_id' must be of type IntegerAttr."
               )

--- a/dialects/src/main/scala-3/lingodb/TupleStream.scala
+++ b/dialects/src/main/scala-3/lingodb/TupleStream.scala
@@ -195,7 +195,7 @@ case class ReturnOp(
     properties.size
   ) match {
     case (0, 0, 0, 0) => Right(this)
-    case _ =>
+    case _            =>
       Left(
         "ReturnOp Operation must contain only results and an attribute dictionary."
       )
@@ -278,7 +278,7 @@ case class GetColumnOp(
           case Some(x) =>
             x match {
               case _: ColumnRefAttr => Right(this)
-              case _ =>
+              case _                =>
                 Left(
                   "GetColumnOp Operation must contain a ColumnRefAttr Attribute."
                 )

--- a/dialects/src/main/scala-3/llvm/LLVM.scala
+++ b/dialects/src/main/scala-3/llvm/LLVM.scala
@@ -11,8 +11,7 @@ case class Ptr() extends DerivedAttribute["llvm.ptr", Ptr] with TypeAttribute
 case class Load(
     ptr: Operand[Ptr],
     result: Result[Attribute]
-) extends DerivedOperation["llvm.load", Load]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["llvm.load", Load] derives DerivedOperationCompanion
 
 case class GetElementPtr(
     base: Operand[Ptr],

--- a/dialects/src/main/scala-3/math/Math.scala
+++ b/dialects/src/main/scala-3/math/Math.scala
@@ -58,7 +58,7 @@ case class AbsfOp(
     properties.size
   ) match {
     case (1, 1, 0, 0, 0) => Right(this)
-    case _ =>
+    case _               =>
       Left(
         "AbsfOp must have 1 result and 1 operand."
       )
@@ -121,7 +121,7 @@ case class FPowIOp(
     properties.size
   ) match {
     case (2, 1, 0, 0, 0) => Right(this)
-    case _ =>
+    case _               =>
       Left(
         "FPowIOp must have 1 result and 2 operands."
       )

--- a/dialects/src/main/scala-3/scf/scf.scala
+++ b/dialects/src/main/scala-3/scf/scf.scala
@@ -28,8 +28,7 @@ case class ForOp(
     initArgs: Operand[Attribute],
     region: Region,
     resultss: Seq[Result[Attribute]]
-) extends DerivedOperation["scf.for", ForOp]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["scf.for", ForOp] derives DerivedOperationCompanion
 
 case class ForallOp(
     dynamicLowerBound: Operand[Index],
@@ -56,8 +55,7 @@ case class IfOp(
     thenRegion: Region,
     elseRegion: Region,
     resultss: Seq[Result[Attribute]]
-) extends DerivedOperation["scf.if", IfOp]
-    derives DerivedOperationCompanion
+) extends DerivedOperation["scf.if", IfOp] derives DerivedOperationCompanion
 
 case class ParallelOp(
     lowerBound: Seq[Operand[Index]],


### PR DESCRIPTION
I'm using fancy new syntax in my upcoming PR and this crashes our current version of scalafmt. 

The mentionned syntax is case class fields matching by name, mentionned as a benefit of the Named Tuples addition at https://www.scala-lang.org/news/3.7.0/#sip-58-named-tuples !