### PR TITLE
Macros better refactoring

### DIFF
--- a/clair/src/main/scala-3/Macros.scala
+++ b/clair/src/main/scala-3/Macros.scala
@@ -488,7 +488,6 @@ def partitionConstructs[Def <: OpInputDef: Type](
   */
 def verifiyConstructs[Def <: OpInputDef: Type](
     defs: Seq[Def],
-    op: Expr[DerivedOperationCompanion[?]#UnverifiedOp],
     partitioned: Seq[Expr[DefinedInput[Def] | Seq[DefinedInput[Def]]]]
 )(using Quotes) = {
   (partitioned zip defs).map { (c, d) =>
@@ -558,7 +557,7 @@ def verifiedConstructs[Def <: OpInputDef: Type](
   )
 
   // Verify the constructs
-  verifiyConstructs(defs, op, partitioned)
+  verifiyConstructs(defs, partitioned)
 }
 
 /** Return all named arguments for the primary constructor of an ADT. Those are


### PR DESCRIPTION
This time is about going slightly further - makings bits and cogs reusable, and trying to understand some subtelties on the way if possible. I'm still missing something with regards to juggling type information, for example...

Changes:
- Different verifiers for each variadicity factored out :heavy_check_mark: Now just give a single OpInputDef, and receive the corresponding typed construct verifier.
  - -> We can use that to experiment assembly format direct parsing to ADT.