### PR TITLE
Uses bookkeeeping at the block level

### DIFF
--- a/core/src/main/scala-3/ir/BlockOperations.scala
+++ b/core/src/main/scala-3/ir/BlockOperations.scala
@@ -1,0 +1,51 @@
+package scair.ir
+
+// import scair.ir.*
+
+opaque type BlockOperations <: collection.Seq[Operation] = ListType[Operation]
+
+private def handleOperationInsertion(op: Operation) =
+  op.operands.zipWithIndex.foreach((o, i) => o.uses += Use(op, i))
+
+private def handleOperationRemoval(op: Operation) =
+  op.operands.zipWithIndex.foreach((o, i) =>
+    o.uses.filterInPlace(_.operation != op)
+  )
+
+extension (b: BlockOperations)
+
+//   def foreach(f: Operation => Unit) = b.foreach(f)
+//   def lastIndexOf(op: Operation): Int = b.lastIndexOf(op)
+  def insertAll(index: Int, ops: IterableOnce[Operation]): Unit =
+    b.insertAll(index, ops)
+    ops.foreach(handleOperationInsertion)
+
+//   def length: Int = b.length
+//   def zipWithIndex: ListType[(Operation, Int)] = b.zipWithIndex
+//   def foldLeft[A](z: A)(op: (A, Operation) => A): A =
+//     b.foldLeft(z)(op)
+  def update(i: Int, op: Operation): Unit =
+    handleOperationRemoval(b(i))
+    b.update(i, op)
+    handleOperationInsertion(op)
+
+  def -=(op: Operation): Unit =
+    b -= op
+    handleOperationRemoval(op)
+
+  def ++=(ops: IterableOnce[Operation]): Unit =
+    b ++= ops
+    ops.foreach(handleOperationInsertion)
+
+object BlockOperations:
+  def unapplySeq(x: BlockOperations) = ListType.unapplySeq(x)
+
+  def apply(ops: Operation*): BlockOperations =
+    ops.foreach(handleOperationInsertion)
+    ListType(ops*)
+
+  def from(coll: collection.IterableOnce[Operation]): BlockOperations =
+    coll.foreach(handleOperationInsertion)
+    ListType.from(coll)
+
+  def empty: BlockOperations = ListType.empty[Operation]

--- a/core/src/main/scala-3/ir/Operation.scala
+++ b/core/src/main/scala-3/ir/Operation.scala
@@ -34,7 +34,6 @@ trait Operation extends IRNode {
   final override def parent = container_block
 
   regions.foreach(attach_region)
-  operands.zipWithIndex.foreach((o, i) => o.uses.addOne(Use(this, i)))
 
   results.foreach(r =>
     // if r.owner != None then
@@ -103,7 +102,6 @@ trait Operation extends IRNode {
 
   final def drop_all_references: Unit = {
     container_block = None
-    operands.foreach(_.uses.filterInPlace(_.operation != this))
   }
 
   final def erase(safe_erase: Boolean = true): Unit = {

--- a/core/src/main/scala-3/ir/Value.scala
+++ b/core/src/main/scala-3/ir/Value.scala
@@ -24,19 +24,11 @@ class Value[+T <: Attribute](
     val typ: T
 ) {
 
-  val uses: ListType[Use] = ListType()
+  val uses: collection.mutable.Set[Use] = collection.mutable.Set.empty[Use]
   var owner: Option[Operation | Block] = None
 
-  def remove_use(use: Use): Unit = {
-    val usesLengthBefore = uses.length
-    uses -= use
-    if (usesLengthBefore == uses.length) then {
-      throw new Exception("Use to be removed was not in the Use list.")
-    }
-  }
-
   def erase(): Unit = {
-    if (uses.length != 0) then
+    if (uses.nonEmpty) then
       throw new Exception(
         "Attempting to erase a Value that has uses in other operations."
       )

--- a/core/src/main/scala-3/transformations/PatternRewriter.scala
+++ b/core/src/main/scala-3/transformations/PatternRewriter.scala
@@ -215,7 +215,6 @@ trait Rewriter {
           )
         }
       }
-      value.uses.clear()
     }
   }
 

--- a/core/test/src/scala-3/ParserTest.scala
+++ b/core/test/src/scala-3/ParserTest.scala
@@ -453,36 +453,17 @@ class ParserTest
       val uses1 = value.regions(0).blocks(0).operations(4).results(1).uses
       val uses2 = value.regions(0).blocks(0).operations(4).results(2).uses
 
-      uses0.length shouldEqual 4
-      uses0(0).operation.name shouldEqual "op1"
-      uses0(0).index shouldEqual 0
-      uses0(1).operation.name shouldEqual "op2"
-      uses0(1).index shouldEqual 0
-      uses0(2).operation.name shouldEqual "op3"
-      uses0(2).index shouldEqual 0
-      uses0(3).operation.name shouldEqual "op4"
-      uses0(3).index shouldEqual 0
+      uses0.size shouldEqual 4
+      uses0.map(use => (use.operation.name, use.index)) shouldEqual
+        Set(("op1", 0), ("op2", 0), ("op3", 0), ("op4", 0))
 
-      uses1.length shouldEqual 4
-      uses1(0).operation.name shouldEqual "op1"
-      uses1(0).index shouldEqual 1
-      uses1(1).operation.name shouldEqual "op2"
-      uses1(1).index shouldEqual 1
-      uses1(2).operation.name shouldEqual "op3"
-      uses1(2).index shouldEqual 1
-      uses1(3).operation.name shouldEqual "op4"
-      uses1(3).index shouldEqual 1
+      uses1.size shouldEqual 4
+      uses1.map(use => (use.operation.name, use.index)) shouldEqual
+        Set(("op1", 1), ("op2", 1), ("op3", 1), ("op4", 1))
 
-      uses2.length shouldEqual 4
-      uses2(0).operation.name shouldEqual "op1"
-      uses2(0).index shouldEqual 2
-      uses2(1).operation.name shouldEqual "op2"
-      uses2(1).index shouldEqual 2
-      uses2(2).operation.name shouldEqual "op3"
-      uses2(2).index shouldEqual 2
-      uses2(3).operation.name shouldEqual "op4"
-      uses2(3).index shouldEqual 2
-
+      uses2.size shouldEqual 4
+      uses2.map(use => (use.operation.name, use.index)) shouldEqual
+        Set(("op1", 2), ("op2", 2), ("op3", 2), ("op4", 2))
     }
   }
 
@@ -504,36 +485,17 @@ class ParserTest
       val uses1 = value.regions(0).blocks(0).operations(0).results(1).uses
       val uses2 = value.regions(0).blocks(0).operations(0).results(2).uses
 
-      uses0.length shouldEqual 4
-      uses0(0).operation.name shouldEqual "op1"
-      uses0(0).index shouldEqual 0
-      uses0(1).operation.name shouldEqual "op2"
-      uses0(1).index shouldEqual 0
-      uses0(2).operation.name shouldEqual "op3"
-      uses0(2).index shouldEqual 0
-      uses0(3).operation.name shouldEqual "op4"
-      uses0(3).index shouldEqual 0
+      uses0.size shouldEqual 4
+      uses0.map(use => (use.operation.name, use.index)) shouldEqual
+        Set(("op1", 0), ("op2", 0), ("op3", 0), ("op4", 0))
 
-      uses1.length shouldEqual 4
-      uses1(0).operation.name shouldEqual "op1"
-      uses1(0).index shouldEqual 1
-      uses1(1).operation.name shouldEqual "op2"
-      uses1(1).index shouldEqual 1
-      uses1(2).operation.name shouldEqual "op3"
-      uses1(2).index shouldEqual 1
-      uses1(3).operation.name shouldEqual "op4"
-      uses1(3).index shouldEqual 1
+      uses1.size shouldEqual 4
+      uses1.map(use => (use.operation.name, use.index)) shouldEqual
+        Set(("op1", 1), ("op2", 1), ("op3", 1), ("op4", 1))
 
-      uses2.length shouldEqual 4
-      uses2(0).operation.name shouldEqual "op1"
-      uses2(0).index shouldEqual 2
-      uses2(1).operation.name shouldEqual "op2"
-      uses2(1).index shouldEqual 2
-      uses2(2).operation.name shouldEqual "op3"
-      uses2(2).index shouldEqual 2
-      uses2(3).operation.name shouldEqual "op4"
-      uses2(3).index shouldEqual 2
-
+      uses2.size shouldEqual 4
+      uses2.map(use => (use.operation.name, use.index)) shouldEqual
+        Set(("op1", 2), ("op2", 2), ("op3", 2), ("op4", 2))
     }
   }
 

--- a/dialects/test/src/scala-3/ArithTest.scala
+++ b/dialects/test/src/scala-3/ArithTest.scala
@@ -74,7 +74,7 @@ builtin.module {
 
     val func = module.regions.head.blocks.head.operations.head
     val arg = func.regions.head.blocks.head.arguments.head
-    val ListType(_, add, ret) = func.regions.head.blocks.head.operations
+    val BlockOperations(_, add, ret) = func.regions.head.blocks.head.operations
     RewriteMethods.replace_op(add, Seq(), Some(Seq(arg)))
     RewriteMethods.erase_op(zero)
 


### PR DESCRIPTION
Such as no use of an operand is recorded, before the user operation is actually inserted in IR.
Given ScaIR's memory management and immutability-based design, this avoids having to manually revert uses from operations created without being used.
Also, make uses a Set.