### PR TITLE
SNAPSHOT publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,17 @@ Include in your project via:
 
 - SBT:
 ```scala
+// To consume -SNAPSHOT versions (recommended)
+resolvers += "Maven Central Snapshots" at "https://central.sonatype.com/repository/maven-snapshots"
 libraryDependencies += "io.github.edin-dal" % "scair-tools_3" % "<version>"
 ```
 - Mill:
 ```scala
-    def ivyDeps = Agg(
+    // To consume -SNAPSHOT versions (recommended)
+    override def repositories = Seq("https://central.sonatype.com/repository/maven-snapshots")
+    override def mvnDeps = Seq(
       ...,
-      ivy"io.github.edin-dal::scair-tools_3:<version>",
+      mvn"io.github.edin-dal::scair-tools_3:<version>",
       ...
     )
 ```

--- a/build.mill
+++ b/build.mill
@@ -84,7 +84,7 @@ trait ScairModule extends ScalafixModule with SonatypeCentralPublishModule with 
   
   override lazy val scoverage : ScairScoverageData = new ScairScoverageData {}
 
-  override def publishVersion = VcsVersion.vcsState().format()
+  override def publishVersion = VcsVersion.vcsState().format(untaggedSuffix = "-SNAPSHOT")
 
   object test extends ScoverageTests with TestModule.ScalaTest {
     override def mvnDeps = Seq(mvn"org.scalatest::scalatest:3.2.19")


### PR DESCRIPTION
We can finally publish SNAPSHOT releases for our running main branch releases!
Those involve less verification and are not meant to be definitive and immutable. They won't also be listed in real "versions" of the packages online, where we can now publish real versions once in a while instead.