### PR TITLE
Rework attribute Alias printing

### DIFF
--- a/clair/src/main/scala-3/Macros.scala
+++ b/clair/src/main/scala-3/Macros.scala
@@ -783,7 +783,7 @@ def derivedAttributeCompanion[T: Type](using
     new DerivedAttributeCompanion[T] {
       override def name: String = ${ Expr(attrDef.name) }
       override def parse[$: P](p: AttrParser): P[T] = P(
-        ("<" ~/ p.Type.rep(sep = ",") ~ ">")
+        ("<" ~/ p.AttributeValue.rep(sep = ",") ~ ">")
       ).orElse(Seq())
         .map(x => ${ getAttrConstructor[T](attrDef, '{ x }) })
       def parameters(attr: T): Seq[Attribute | Seq[Attribute]] = ${

--- a/clair/src/main/scala-3/Macros.scala
+++ b/clair/src/main/scala-3/Macros.scala
@@ -783,7 +783,7 @@ def derivedAttributeCompanion[T: Type](using
     new DerivedAttributeCompanion[T] {
       override def name: String = ${ Expr(attrDef.name) }
       override def parse[$: P](p: AttrParser): P[T] = P(
-        ("<" ~/ p.AttributeValue.rep(sep = ",") ~ ">")
+        ("<" ~/ p.Attribute.rep(sep = ",") ~ ">")
       ).orElse(Seq())
         .map(x => ${ getAttrConstructor[T](attrDef, '{ x }) })
       def parameters(attr: T): Seq[Attribute | Seq[Attribute]] = ${

--- a/core/src/main/scala-3/Printer.scala
+++ b/core/src/main/scala-3/Printer.scala
@@ -20,12 +20,10 @@ case class Printer(
     var valueNextID: Int = 0,
     var blockNextID: Int = 0,
     val valueNameMap: mutable.Map[Value[? <: Attribute], String] =
-      mutable.Map.empty[Value[? <: Attribute], String],
-    val blockNameMap: mutable.Map[Block, String] =
-      mutable.Map.empty[Block, String],
+      mutable.Map.empty,
+    val blockNameMap: mutable.Map[Block, String] = mutable.Map.empty,
     private val p: PrintWriter = new PrintWriter(System.out),
-    private var aliasesMap: Map[Attribute, String] =
-      Map.empty[Attribute, String]
+    private var aliasesMap: Map[Attribute, String] = Map.empty
 ) {
 
   /*≡==--==≡≡≡==--=≡≡*\
@@ -70,6 +68,15 @@ case class Printer(
     aliasesMap.get(attribute) match
       case Some(alias) => print(alias)
       case None        => attribute.custom_print(this)
+
+  def print(attributes: Seq[Attribute]): Unit =
+    printList(attributes, "[", ", ", "]")
+
+  def print(parameter: Attribute | Seq[Attribute]): Unit =
+    parameter match {
+      case seq: Seq[_]     => printList(seq.asInstanceOf[Seq[Attribute]])
+      case attr: Attribute => print(attr)
+    }
 
   /*≡==--==≡≡≡≡≡≡≡==--=≡≡*\
   ||    VALUE PRINTER    ||
@@ -166,48 +173,12 @@ case class Printer(
     print(indent * indentLevel + "}")
   }
 
-  @targetName("aliasesOps")
-  def aliases(ops: Seq[Operation]): LinkedHashSet[AliasedAttribute] =
-    ops.flatMap(aliases).to(LinkedHashSet)
-
-  def aliases(op: Operation): LinkedHashSet[AliasedAttribute] =
-    (op.properties.values ++ op.attributes.values ++ op.operands.typ ++ op.results.typ)
-      .flatMap(aliases)
-      .to(LinkedHashSet) ++ op.regions.flatMap(aliases).to(LinkedHashSet)
-
-  def aliases(reg: Region): LinkedHashSet[AliasedAttribute] =
-    reg.blocks.flatMap(aliases).to(LinkedHashSet)
-
-  def aliases(block: Block): LinkedHashSet[AliasedAttribute] =
-    block.arguments
-      .map(_.typ)
-      .flatMap(aliases)
-      .to(LinkedHashSet) ++ (block.operations
-      .flatMap(aliases))
-      .to(LinkedHashSet)
-
-  @targetName("aliasesAttrs")
-  def aliases(attr: Seq[Attribute]): LinkedHashSet[AliasedAttribute] =
-    attr.flatMap(aliases).to(LinkedHashSet)
-
-  def aliases(attr: Attribute): LinkedHashSet[AliasedAttribute] =
-    val p = attr match
-      case p: ParametrizedAttribute =>
-        p.parameters
-          .flatMap(_ match
-            case a: Attribute        => aliases(a)
-            case seq: Seq[Attribute] => aliases(seq))
-          .to(LinkedHashSet)
-      case _ => LinkedHashSet.empty[AliasedAttribute]
-    attr match
-      case a: AliasedAttribute => p + a
-      case _                   => p
-
   def printAliases(ops: Seq[Operation]) =
-    val toAlias = aliases(ops)
+    val printer = AliasPrinter(strictly_generic = strictly_generic, p = p)
+    printer.print(ops)(using indentLevel = 0)
     val aliasesMap = mutable.Map.empty[Attribute, String]
     val aliasesCounters = mutable.Map.empty[String, Int]
-    toAlias.foreach(attr =>
+    printer.toAlias.foreach(attr =>
       aliasesMap.getOrElseUpdate(
         attr, {
           val alias = attr.alias
@@ -311,5 +282,40 @@ case class Printer(
       case seq: Seq[Operation] => seq
     printAliases(ops)
     print(ops)(using indentLevel = 0)
+
+}
+
+class AliasPrinter(
+    strictly_generic: Boolean = false,
+    private val p: PrintWriter = new PrintWriter(System.out),
+    val toAlias: mutable.LinkedHashSet[AliasedAttribute] =
+      mutable.LinkedHashSet.empty
+) extends Printer(strictly_generic = strictly_generic, p = p) {
+
+  override def copy(
+      strictly_generic: Boolean = false,
+      indent: String = "  ",
+      valueNextID: Int = 0,
+      blockNextID: Int = 0,
+      valueNameMap: mutable.Map[Value[? <: Attribute], String] =
+        mutable.Map.empty,
+      blockNameMap: mutable.Map[Block, String] = mutable.Map.empty,
+      p: PrintWriter = new PrintWriter(System.out),
+      aliasesMap: Map[Attribute, String] = Map.empty
+  ): AliasPrinter =
+    new AliasPrinter(
+      strictly_generic = strictly_generic,
+      p = p,
+      toAlias = toAlias
+    )
+
+  override def print(string: String) = ()
+
+  override def print(attribute: Attribute): Unit = {
+    attribute.custom_print(this)
+    attribute match
+      case aliased: AliasedAttribute => toAlias.add(aliased)
+      case _                         => ()
+  }
 
 }

--- a/core/src/main/scala-3/Printer.scala
+++ b/core/src/main/scala-3/Printer.scala
@@ -3,7 +3,6 @@ package scair
 import scair.ir.*
 
 import java.io.*
-import scala.annotation.targetName
 import scala.collection.mutable
 import scala.collection.mutable.LinkedHashSet
 

--- a/core/src/main/scala-3/ir/Attribute.scala
+++ b/core/src/main/scala-3/ir/Attribute.scala
@@ -37,33 +37,17 @@ trait TypeAttribute extends Attribute {
   override def prefix: String = "!"
 }
 
-// TODO: Think about this; probably not the best design
-extension (x: Seq[Attribute] | Attribute)
-
-  def custom_print(p: Printer): Unit = x match {
-    case attr: Attribute => attr.custom_print(p)
-    case x: Seq[_]       =>
-      p.printList(
-        x.asInstanceOf[Seq[Attribute]],
-        "[",
-        ", ",
-        "]"
-      )
-      x.asInstanceOf[Seq[Attribute]]
-        .map(_.custom_print(p))
-        .mkString("[", ", ", "]")
-  }
-
 abstract class ParametrizedAttribute() extends Attribute {
 
   def parameters: Seq[Attribute | Seq[Attribute]]
 
   override def custom_print(p: Printer) =
-    p.print(prefix, name)(using indentLevel = 0)
+    given indentLevel: Int = 0
+    p.print(prefix, name)
     if parameters.size > 0 then
       p.printListF(
         parameters,
-        (x: Attribute | Seq[Attribute]) => x.custom_print(p),
+        p.print,
         "<",
         ", ",
         ">"

--- a/dialects/src/main/scala-3/func/Func.scala
+++ b/dialects/src/main/scala-3/func/Func.scala
@@ -100,7 +100,7 @@ case class Func(
         lprinter.print(" {\n")
         entry.operations.foreach(lprinter.print(_)(using indentLevel + 1))
         others.foreach(lprinter.print)
-        print(lprinter.indent * indentLevel + "}")
+        lprinter.print(lprinter.indent * indentLevel + "}")
 
 case class Return(
     _operands: Seq[Operand[Attribute]]

--- a/dialects/test/src/scala-3/ArithTest.scala
+++ b/dialects/test/src/scala-3/ArithTest.scala
@@ -67,7 +67,7 @@ builtin.module {
     %1 = "arith.constant"() <{value = 0 : i32}> : () -> (i32)
     %2 = "arith.addi"(%0, %1) : (i32, i32) -> (i32)
     func.return %2 : i32
-
+  }
 }
 """.trim()
 
@@ -83,7 +83,7 @@ builtin.module {
 builtin.module {
   func.func @suchCompute(%0: i32) -> i32 {
     func.return %0 : i32
-
+  }
 }
 """.trim()
   }


### PR DESCRIPTION
Stacked on:
- #311 

Take inspiration from MLIR for printing aliases - instead of navigating through the IR with custom code, just create a special printer which prints nothing and only records attributes to be aliased. This allows to handle any attribute, operations and syntax transparently and alias all and only the attributes that should be, as it will navigate in each syntax as the actual printer would (including parameters, properties, anything elides through custom syntax, ...)