### PR TITLE
Merge all Values types

### DIFF
--- a/clair/src/main/scala-3/Mirror.scala
+++ b/clair/src/main/scala-3/Mirror.scala
@@ -53,13 +53,13 @@ def getDefInput[Label: Type, Elem: Type](using Quotes): OpInputDef = {
       Type.valueOfConstant[Label].get.asInstanceOf[String]
   val (variadicity, elem) = getDefVariadicityAndType[Elem]
   elem match
-    case '[Result[t]] =>
+    case '[Value[t]] if TypeRepr.of[Result[t]] =:= TypeRepr.of(using elem) =>
       ResultDef(
         name = name,
         tpe = Type.of[t],
         variadicity
       )
-    case '[Operand[t]] =>
+    case '[Value[t]] =>
       OperandDef(
         name = name,
         tpe = Type.of[t],

--- a/core/src/main/scala-3/ir/IRUtils.scala
+++ b/core/src/main/scala-3/ir/IRUtils.scala
@@ -22,11 +22,6 @@ import scala.collection.mutable.ListBuffer
 \*≡==---==≡≡≡≡≡==---==≡*/
 // for ClairV2
 
-type Operand[+T <: Attribute] = Value[T]
-
-case class Result[+T <: Attribute](override val typ: T)
-    extends Value[T](typ = typ)
-
 type Successor = Block
 
 /*≡==--==≡≡≡==--=≡≡*\

--- a/core/src/main/scala-3/ir/Value.scala
+++ b/core/src/main/scala-3/ir/Value.scala
@@ -13,14 +13,9 @@ package scair.ir
 
 // TO-DO: perhaps a linked list of a use to other uses within an operation
 //        for faster use retrieval and index update
-case class Use(val operation: Operation, val index: Int)
+final case class Use(val operation: Operation, val index: Int)
 
-object Value {
-  def apply[T <: Attribute](typ: T): Value[T] = new Value(typ)
-  def unapply[T <: Attribute](value: Value[T]): Option[T] = Some(value.typ)
-}
-
-class Value[+T <: Attribute](
+final case class Value[+T <: Attribute](
     val typ: T
 ) {
 
@@ -43,5 +38,14 @@ class Value[+T <: Attribute](
   override final def hashCode(): Int = System.identityHashCode(this)
 
 }
+
+type Operand[+T <: Attribute] = Value[T]
+
+opaque type Result[+T <: Attribute] <: Value[T] = Value[T]
+
+object Result:
+  def apply[T <: Attribute](typ: T): Result[T] = Value(typ)
+  def unapply[T <: Attribute](r: Result[T]): Some[T] = Some(r.typ)
+  given [T <: Attribute] => Conversion[Result[T], Value[T]] = identity
 
 extension (seq: Seq[Value[Attribute]]) def typ: Seq[Attribute] = seq.map(_.typ)

--- a/core/src/main/scala-3/ir/Value.scala
+++ b/core/src/main/scala-3/ir/Value.scala
@@ -46,6 +46,13 @@ opaque type Result[+T <: Attribute] <: Value[T] = Value[T]
 object Result:
   def apply[T <: Attribute](typ: T): Result[T] = Value(typ)
   def unapply[T <: Attribute](r: Result[T]): Some[T] = Some(r.typ)
-  given [T <: Attribute] => Conversion[Result[T], Value[T]] = identity
+  given [T <: Attribute] => Conversion[Value[T], Result[T]] = identity
+
+opaque type BlockArgument[+T <: Attribute] <: Value[T] = Value[T]
+
+object BlockArgument:
+  def apply[T <: Attribute](typ: T): BlockArgument[T] = Value(typ)
+  def unapply[T <: Attribute](r: BlockArgument[T]): Some[T] = Some(r.typ)
+  given [T <: Attribute] => Conversion[Value[T], BlockArgument[T]] = identity
 
 extension (seq: Seq[Value[Attribute]]) def typ: Seq[Attribute] = seq.map(_.typ)


### PR DESCRIPTION
Keep Operand as a type alias (avoids changing it everywhere, and I don't dislike the readability on Ops)
Make Result an *opaque* alias, to differentiate it in Mirroring, while keeping it compiled as just a Value.

Should simplify other things