### PR TITLE
Optimize construct flattening

### DIFF
--- a/core/src/main/scala-3/clair/Macros.scala
+++ b/core/src/main/scala-3/clair/Macros.scala
@@ -95,14 +95,19 @@ def ADTFlatInputMacro[Def <: OpInputDef: Type](
     opInputDefs: Seq[Def],
     adtOpExpr: Expr[?]
 )(using Quotes): Expr[Seq[DefinedInput[Def]]] = {
-  val stuff = 
-    opInputDefs.map((d: Def) => selectMember[DefinedInput[Def] | IterableOnce[DefinedInput[Def]]](adtOpExpr, d.name)
+  val stuff =
+    opInputDefs.map((d: Def) =>
+      selectMember[DefinedInput[Def] | IterableOnce[DefinedInput[Def]]](
+        adtOpExpr,
+        d.name
+      )
     )
-  stuff.foldLeft('{Seq.empty[DefinedInput[Def]]})((seq, next) => next match
-    case '{$ns : IterableOnce[DefinedInput[Def]]} => '{$seq :++ $ns}
-    case '{$ne : DefinedInput[Def]} => '{$seq :+ $ne}
+  stuff.foldLeft('{ Seq.empty[DefinedInput[Def]] })((seq, next) =>
+    next match
+      case '{ $ns: IterableOnce[DefinedInput[Def]] } => '{ $seq :++ $ns }
+      case '{ $ne: DefinedInput[Def] }               => '{ $seq :+ $ne }
   )
-  
+
 }
 
 def operandsMacro(

--- a/core/src/main/scala-3/clair/Macros.scala
+++ b/core/src/main/scala-3/clair/Macros.scala
@@ -104,8 +104,8 @@ def ADTFlatInputMacro[Def <: OpInputDef: Type](
     )
   stuff.foldLeft('{ Seq.empty[DefinedInput[Def]] })((seq, next) =>
     next match
-      case '{ $ns: IterableOnce[DefinedInput[Def]] } => '{ $seq :++ $ns }
       case '{ $ne: DefinedInput[Def] }               => '{ $seq :+ $ne }
+      case '{ $ns: IterableOnce[DefinedInput[Def]] } => '{ $seq :++ $ns }
   )
 
 }

--- a/core/src/main/scala-3/clair/Macros.scala
+++ b/core/src/main/scala-3/clair/Macros.scala
@@ -67,15 +67,17 @@ def makeSegmentSizes[T <: MayVariadicOpInputDef: Type](
           )
         )
       Some(
-        name -> '{DenseArrayAttr(
-          IntegerType(IntData(32), Signless),
-          ${ arrayAttr }.map(x =>
-            IntegerAttr(
-              IntData(x),
-              IntegerType(IntData(32), Signless)
+        name -> '{
+          DenseArrayAttr(
+            IntegerType(IntData(32), Signless),
+            ${ arrayAttr }.map(x =>
+              IntegerAttr(
+                IntData(x),
+                IntegerType(IntData(32), Signless)
+              )
             )
           )
-        )}
+        }
       )
     case false => None
   }
@@ -157,20 +159,23 @@ def propertiesMacro(
     adtOpExpr
   )
   // Populating a Dictionarty with the properties
-  val definedProps = if opDef.properties.isEmpty then
-    '{ Map.empty[String, Attribute] }
-  else
-    // extracting property instances from the ADT
-    val propertyExprs = ADTFlatInputMacro(opDef.properties, adtOpExpr)
-    val propertyNames = Expr.ofList(opDef.properties.map((d) => Expr(d.name)))
-    '{
-      Map.from(${ propertyNames } zip ${ propertyExprs })
-    }
+  val definedProps =
+    if opDef.properties.isEmpty then '{ Map.empty[String, Attribute] }
+    else
+      // extracting property instances from the ADT
+      val propertyExprs = ADTFlatInputMacro(opDef.properties, adtOpExpr)
+      val propertyNames = Expr.ofList(opDef.properties.map((d) => Expr(d.name)))
+      '{
+        Map.from(${ propertyNames } zip ${ propertyExprs })
+      }
 
-  Seq(opSegSizeProp, resSegSizeProp, regSegSizeProp, succSegSizeProp).foldLeft(definedProps){
-    case (map, Some((name, segSize))) => '{ $map + (${Expr(name)} -> $segSize) }
-    case (map, None)                  => map
-   }
+  Seq(opSegSizeProp, resSegSizeProp, regSegSizeProp, succSegSizeProp).foldLeft(
+    definedProps
+  ) {
+    case (map, Some((name, segSize))) =>
+      '{ $map + (${ Expr(name) } -> $segSize) }
+    case (map, None) => map
+  }
 
 def customPrintMacro(
     opDef: OperationDef,

--- a/core/src/main/scala-3/clair/Macros.scala
+++ b/core/src/main/scala-3/clair/Macros.scala
@@ -107,7 +107,6 @@ def ADTFlatInputMacro[Def <: OpInputDef: Type](
       case '{ $ne: DefinedInput[Def] }               => '{ $seq :+ $ne }
       case '{ $ns: IterableOnce[DefinedInput[Def]] } => '{ $seq :++ $ns }
   )
-
 }
 
 def operandsMacro(


### PR DESCRIPTION
Flattening the list of constructs was left to the runtime but could be specified at compile-time, as done here.

For example, looking at
```scala
case class Load(
    memref: Operand[MemrefType],
    indices: Seq[Operand[IndexType]],
    result: Result[Attribute]
) extends DerivedOperation["memref.load", Load]
    derives DerivedOperationCompanion
```
This used to generate
```scala
  def operands = Seq(memref, indices).flatten
```
And now generates:
```scala
  def operands = Seq.empty[Operand[Attribute]] :+ memref :++ indices
```