### PR TITLE
Testing and CI tweaks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,8 +106,7 @@ jobs:
         export PATH=$PATH:$(pwd)/llvm-project/build/bin/
         # I can't get it to work with just cleaning the coverage data, for some reason
         # ./mill clean
-        ./mill coverage
-        ./mill filechecks.native
+        ./mill scoverage + filechecks.nativeImage
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v5
       with:

--- a/build.mill
+++ b/build.mill
@@ -19,6 +19,8 @@ import mill.api.Task.{Named, Command}
 import scala.sys.process._
 import scala.language.postfixOps
 import java.io.PrintWriter
+import os.Path
+import mill.api.Task.Simple
 trait ScairSettings extends ScalaModule with NativeImageModule with UnidocModule {
 
   def scoverageVersion = Task{"2.3.0"}
@@ -41,6 +43,8 @@ trait ScairSettings extends ScalaModule with NativeImageModule with UnidocModule
 
 
 trait ScairModule extends ScalafixModule with SonatypeCentralPublishModule with ScoverageModule with ScairSettings {
+
+  def outer = ModuleRef(this)
 
   override def artifactName = s"scair-${super.artifactName()}"
 
@@ -70,17 +74,26 @@ trait ScairModule extends ScalafixModule with SonatypeCentralPublishModule with 
   // coverage when compiling a module with coverage.
   trait ScairScoverageData extends ScoverageData with ScairSettings {
     override def transitiveModuleRunModuleDeps = {
-      super .transitiveModuleRunModuleDeps.map {
+      super.transitiveModuleRunModuleDeps.map {
         case m: ScairModule => m.scoverage
         case m => m
       }
     }
 
     override def transitiveModuleCompileModuleDeps = {
-      super .transitiveModuleCompileModuleDeps.map {
+      super.transitiveModuleCompileModuleDeps.map {
         case m: ScairModule => m.scoverage
         case m => m
       }
+    }
+
+    object test extends ScoverageTests with TestModule.ScalaTest with ScairSettings {
+      override def moduleDir: Path = outer().test.moduleDir
+      override def mvnDeps = Seq(mvn"org.scalatest::scalatest:3.2.19")
+
+      // This was necessary to cooperate with graalvm at time of writing.
+      // Please remove if unit tests work fine without it in the future.
+      override def testParallelism = false
     }
   }
   
@@ -88,7 +101,10 @@ trait ScairModule extends ScalafixModule with SonatypeCentralPublishModule with 
 
   override def publishVersion = VcsVersion.vcsState().format(untaggedSuffix = "-SNAPSHOT")
 
-  object test extends ScoverageTests with TestModule.ScalaTest with ScairSettings {
+  object test extends ScoverageTests with TestModule.ScalaTest with ScairSettings{
+    // Revert that it is a ScoverageTests
+    override def runClasspath: Simple[Seq[PathRef]] = super[ScairSettings].runClasspath()
+
     override def mvnDeps = Seq(mvn"org.scalatest::scalatest:3.2.19")
     // This was necessary to cooperate with graalvm at time of writing.
     // Please remove if unit tests work fine without it in the future.
@@ -131,7 +147,7 @@ object `package` extends ScairSettings with ScoverageReport {
 
   def allScalaSources(evaluator: Evaluator) = Tasks(evaluator.resolveTasks(Seq("__.sources"), SelectMode.Multi).get.asInstanceOf[Seq[Named[Seq[PathRef]]]])
 
-  def runAllUnitTests(evaluator: Evaluator) = Task.sequence(evaluator.resolveTasks(Seq("__.test"), SelectMode.Multi).get.asInstanceOf[Seq[Named[Seq[TestResult]]]])
+  def runAll(query: String, evaluator: Evaluator) = Task.sequence(evaluator.resolveTasks(Seq(query), SelectMode.Multi).get.asInstanceOf[Seq[Named[Seq[TestResult]]]])
    
   def allChildren = allChidrenRec(moduleDirectChildren)
   def allChidrenRec(children: Seq[Module]): Seq[Module] = {
@@ -158,13 +174,13 @@ object `package` extends ScairSettings with ScoverageReport {
 
   // Define a testAll to run the full framework testing infrastructure
   def testAll(evaluator: Evaluator) = Command(exclusive = true) {
-    runAllUnitTests(evaluator)()
+    runAll("_.test", evaluator)()
     filechecks.run()()
   }
 
-  def coverage(evaluator: Evaluator) = Command(exclusive = true) {
-    runAllUnitTests(evaluator)()
-    filechecks.coverage.run()()
+  def scoverage(evaluator: Evaluator) = Command(exclusive = true) {
+    runAll("__.scoverage.test", evaluator)()
+    filechecks.scoverage.run()()
     xmlReportAll(evaluator)()
   }
 
@@ -175,7 +191,7 @@ object `package` extends ScairSettings with ScoverageReport {
     // Make filechecks runnable directly as ./mill filechecks
     override def defaultTask(): String = "run"
     // Define a Mill command to run filechecks
-    def run() = Task.Command {
+    def run() = Task.Command(exclusive = true) {
       // Get the directory root to use as lit's working directory
       val rootPath = rootModule().moduleDir
       // Run lit, forwarding it the relevant scair-opt through the env var
@@ -187,8 +203,8 @@ object `package` extends ScairSettings with ScoverageReport {
   }
   object filechecks extends filechecks:
     override def scairOpt = tools.launcher
-    object coverage extends filechecks:
+    object scoverage extends filechecks:
       override def scairOpt = tools.scoverage.launcher
-    object native extends filechecks:
+    object nativeImage extends filechecks:
       override def scairOpt = tools.nativeImage
 }


### PR DESCRIPTION
- Formerly `.test` is now `.scoverage.test`, to test explicitly with coverage measures.
- Now `.test` is just running the unit tests, *without* coverage measures (and overhead)
- -> Adapt top-level commands to use the right one; `testAll` is free from coverage compilation at last!
- Some renames:
  - `./mill coverage` -> `./mill scoverage`
  - `./mill filechecks.coverage` -> `./mill filechecks.scoverage`
  - `./mill filechecks.native` -> `./mill filechecks.nativeImage`
- Also fixed exclusivity of the filechecks commands! This:
  - Finally stops throwing unit tests and filechecks outputs at once (It's now first unit tests, then filechecks)
  - Allows to use Mill's `+` operator to run multiple top-level or filechecks commands at once - all `lit` invocation will be scheduled separately and it will work out.