### PR TITLE
Refactor build and add Scala Native

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,4 +21,4 @@ jobs:
             MILL_PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
             MILL_SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
             MILL_SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          run: ./mill _.publishSonatypeCentral
+          run: ./mill _.jvm.publishSonatypeCentral

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,7 @@ jobs:
         export PATH=$PATH:$(pwd)/llvm-project/build/bin/
         # I can't get it to work with just cleaning the coverage data, for some reason
         # ./mill clean
-        ./mill scoverage + filechecks.nativeImage
+        ./mill scoverage + filechecks.graal + filechecks.native
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v5
       with:

--- a/build.mill
+++ b/build.mill
@@ -188,7 +188,7 @@ object `package` extends ScairSettings with ScoverageReport with UnidocModule {
 
   def scalafixAll(args: String*) = Command {
     Task.sequence(allChildren
-      .flatMap{case m : ScalafixModule => Some(m.fix(args*))
+      .flatMap{case m : ScairModule => Some(m.jvm.fix(args*))
       case _ => None})()
     }
 

--- a/build.mill
+++ b/build.mill
@@ -21,28 +21,21 @@ import scala.language.postfixOps
 import java.io.PrintWriter
 import os.Path
 import mill.api.Task.Simple
-trait ScairSettings extends ScalaModule with NativeImageModule with UnidocModule {
 
+trait ScairSettings extends ScalaModule {
   def scoverageVersion = Task{"2.3.0"}
+
   override def scalaVersion = "3.7.1"
+
+  override def scalacOptions = super.scalacOptions() ++ Seq("-Wunused:imports", "-explain")
+
+}
+
+
+trait ScairModule extends ScalafixModule with SonatypeCentralPublishModule with ScoverageModule with ScairSettings with NativeImageModule {
+
   override def jvmId = "graalvm-community:24.0.1"
   override def nativeImageOptions = Seq("--no-fallback", "--initialize-at-build-time")
-  override def scalacOptions = super.scalacOptions() ++ Seq("-Wunused:imports", "-explain")
-  override def unidocOptions = super.unidocOptions() ++ Seq("-snippet-compiler:compile")
-
-  override def unidocVersion = Task{Some("0.5.0")}
-  override def unidocDocumentTitle = Task{"ScaIR Unidoc"}
-
-  override def unidocSourceFiles =
-      (Seq(compile().classes) ++ Task.traverse(transitiveModuleDeps)(_.compile)().map(_.classes))
-        .filter(pr => os.exists(pr.path))
-        .flatMap(pr => os.walk(pr.path))
-        .filter(_.ext == "tasty")
-        .map(PathRef(_))
-    }
-
-
-trait ScairModule extends ScalafixModule with SonatypeCentralPublishModule with ScoverageModule with ScairSettings {
 
   def outer = ModuleRef(this)
 
@@ -112,7 +105,17 @@ trait ScairModule extends ScalafixModule with SonatypeCentralPublishModule with 
   }
 }
 
-object `package` extends ScairSettings with ScoverageReport {
+object `package` extends ScairSettings with ScoverageReport with UnidocModule {
+
+  override def unidocOptions = super.unidocOptions() ++ Seq("-snippet-compiler:compile")
+  override def unidocVersion = Task{Some("0.5.0")}
+  override def unidocDocumentTitle = Task{"ScaIR Unidoc"}
+  override def unidocSourceFiles =
+      (Seq(compile().classes) ++ Task.traverse(transitiveModuleDeps)(_.compile)().map(_.classes))
+        .filter(pr => os.exists(pr.path))
+        .flatMap(pr => os.walk(pr.path))
+        .filter(_.ext == "tasty")
+        .map(PathRef(_))
 
   override def moduleDeps = Seq(tools)
 

--- a/build.mill
+++ b/build.mill
@@ -32,7 +32,7 @@ trait ScairSettings extends ScalaModule {
 }
 
 
-trait JvmScairModule extends ScalafixModule with PlatformScalaModule with SonatypeCentralPublishModule with ScoverageModule with ScairSettings with NativeImageModule {
+trait JvmScairModule extends ScalafixModule with PlatformScalaModule with SonatypeCentralPublishModule with ScoverageModule with ScairSettings {
 
   trait ScairTests extends ScalaTests with TestModule.ScalaTest {
     override def mvnDeps = Seq(mvn"org.scalatest::scalatest:3.2.19")
@@ -40,9 +40,6 @@ trait JvmScairModule extends ScalafixModule with PlatformScalaModule with Sonaty
     // Please remove if unit tests work fine without it in the future.
     override def testParallelism = false
   }
-
-  override def jvmId = "graalvm-community:24.0.1"
-  override def nativeImageOptions = Seq("--no-fallback", "--initialize-at-build-time")
 
   def outer = ModuleRef(this)
 
@@ -99,11 +96,21 @@ trait JvmScairModule extends ScalafixModule with PlatformScalaModule with Sonaty
   object test extends ScairTests
 }
 
+trait GraalScairModule extends JvmScairModule with NativeImageModule {
+  override def jvmId = "graalvm-community:24.0.1"
+  override def nativeImageOptions = Seq("--no-fallback", "--initialize-at-build-time")
+}
+
 trait ScairModule extends ScairSettings {
   def agnosticModule = ModuleRef(this)
   def moduleDeps: Seq[ScairModule] = Seq()
   lazy val jvm: JvmScairModule = new JvmScairModule {
     override def moduleDeps = agnosticModule().moduleDeps.map(_.jvm)
+    override def mvnDeps = agnosticModule().mvnDeps
+  }
+
+  lazy val graal: GraalScairModule = new GraalScairModule {
+    override def moduleDeps = agnosticModule().moduleDeps.map(_.graal)
     override def mvnDeps = agnosticModule().mvnDeps
   }
 }
@@ -212,5 +219,5 @@ object `package` extends ScairSettings with ScoverageReport with UnidocModule {
     object scoverage extends filechecks:
       override def scairOpt = tools.jvm.scoverage.launcher
     object nativeImage extends filechecks:
-      override def scairOpt = tools.jvm.nativeImage
+      override def scairOpt = tools.graal.nativeImage
 }

--- a/build.mill
+++ b/build.mill
@@ -87,16 +87,18 @@ trait JvmScairModule extends ScalafixModule with PlatformScalaModule with Sonaty
       }
     }
 
-    object test extends ScoverageTests with ScairTests {
+    trait ScairScoverageTests extends ScoverageTests with ScairTests {
       override def moduleDir: Path = outer().test.moduleDir
     }
+
+    lazy val test = new ScairScoverageTests {}
   }
   
   override lazy val scoverage : ScairScoverageData = new ScairScoverageData {}
 
   override def publishVersion = VcsVersion.vcsState().format(untaggedSuffix = "-SNAPSHOT")
 
-  object test extends ScairTests
+  lazy val test = new ScairTests {}
 }
 
 trait GraalScairModule extends JvmScairModule with NativeImageModule {
@@ -107,6 +109,10 @@ trait NativeScairModule extends JvmScairModule with ScalaNativeModule {
   override def scalaNativeVersion = "0.5.8"
   override def nativeLTO: Simple[LTO] = LTO.Full
   override def releaseMode: Simple[ReleaseMode] = ReleaseMode.ReleaseFull
+  override object scoverage extends ScairScoverageData {
+    override object test extends ScairScoverageTests with ScalaNativeTests {}
+  }
+  override object test extends ScairTests with ScalaNativeTests
 }
 
 trait ScairModule extends ScairSettings {

--- a/build.mill
+++ b/build.mill
@@ -210,7 +210,7 @@ object `package` extends ScairSettings with ScoverageReport with UnidocModule {
     filechecks.run()()
   }
 
-  def scoverage(evaluator: Evaluator) = Command {
+  def scoverage(evaluator: Evaluator) = Command(exclusive = true) {
     runAll("_.jvm.scoverage.test", evaluator)()
     filechecks.scoverage.run()()
     xmlReportAll(evaluator)()

--- a/build.mill
+++ b/build.mill
@@ -21,6 +21,7 @@ import scala.language.postfixOps
 import java.io.PrintWriter
 import os.Path
 import mill.api.Task.Simple
+import mill.scalalib.PlatformScalaModule
 
 trait ScairSettings extends ScalaModule {
   def scoverageVersion = Task{"2.3.0"}
@@ -31,7 +32,7 @@ trait ScairSettings extends ScalaModule {
 }
 
 
-trait ScairModule extends ScalafixModule with SonatypeCentralPublishModule with ScoverageModule with ScairSettings with NativeImageModule {
+trait JvmScairModule extends ScalafixModule with PlatformScalaModule with SonatypeCentralPublishModule with ScoverageModule with ScairSettings with NativeImageModule {
 
   trait ScairTests extends ScalaTests with TestModule.ScalaTest {
     override def mvnDeps = Seq(mvn"org.scalatest::scalatest:3.2.19")
@@ -74,14 +75,14 @@ trait ScairModule extends ScalafixModule with SonatypeCentralPublishModule with 
   trait ScairScoverageData extends ScoverageData with ScairSettings {
     override def transitiveModuleRunModuleDeps = {
       super.transitiveModuleRunModuleDeps.map {
-        case m: ScairModule => m.scoverage
+        case m: ScairModule => m.jvm.scoverage
         case m => m
       }
     }
 
     override def transitiveModuleCompileModuleDeps = {
       super.transitiveModuleCompileModuleDeps.map {
-        case m: ScairModule => m.scoverage
+        case m: ScairModule => m.jvm.scoverage
         case m => m
       }
     }
@@ -96,6 +97,15 @@ trait ScairModule extends ScalafixModule with SonatypeCentralPublishModule with 
   override def publishVersion = VcsVersion.vcsState().format(untaggedSuffix = "-SNAPSHOT")
 
   object test extends ScairTests
+}
+
+trait ScairModule extends ScairSettings {
+  def agnosticModule = ModuleRef(this)
+  def moduleDeps: Seq[ScairModule] = Seq()
+  lazy val jvm: JvmScairModule = new JvmScairModule {
+    override def moduleDeps = agnosticModule().moduleDeps.map(_.jvm)
+    override def mvnDeps = agnosticModule().mvnDeps
+  }
 }
 
 object `package` extends ScairSettings with ScoverageReport with UnidocModule {
@@ -170,12 +180,12 @@ object `package` extends ScairSettings with ScoverageReport with UnidocModule {
 
   // Define a testAll to run the full framework testing infrastructure
   def testAll(evaluator: Evaluator) = Command(exclusive = true) {
-    runAll("_.test", evaluator)()
+    runAll("_.jvm.test", evaluator)()
     filechecks.run()()
   }
 
   def scoverage(evaluator: Evaluator) = Command(exclusive = true) {
-    runAll("__.scoverage.test", evaluator)()
+    runAll("_.jvm.scoverage.test", evaluator)()
     filechecks.scoverage.run()()
     xmlReportAll(evaluator)()
   }
@@ -200,7 +210,7 @@ object `package` extends ScairSettings with ScoverageReport with UnidocModule {
   object filechecks extends filechecks:
     override def scairOpt = tools.launcher
     object scoverage extends filechecks:
-      override def scairOpt = tools.scoverage.launcher
+      override def scairOpt = tools.jvm.scoverage.launcher
     object nativeImage extends filechecks:
-      override def scairOpt = tools.nativeImage
+      override def scairOpt = tools.jvm.nativeImage
 }

--- a/build.mill
+++ b/build.mill
@@ -28,11 +28,17 @@ trait ScairSettings extends ScalaModule {
   override def scalaVersion = "3.7.1"
 
   override def scalacOptions = super.scalacOptions() ++ Seq("-Wunused:imports", "-explain")
-
 }
 
 
 trait ScairModule extends ScalafixModule with SonatypeCentralPublishModule with ScoverageModule with ScairSettings with NativeImageModule {
+
+  trait ScairTests extends ScalaTests with TestModule.ScalaTest {
+    override def mvnDeps = Seq(mvn"org.scalatest::scalatest:3.2.19")
+    // This was necessary to cooperate with graalvm at time of writing.
+    // Please remove if unit tests work fine without it in the future.
+    override def testParallelism = false
+  }
 
   override def jvmId = "graalvm-community:24.0.1"
   override def nativeImageOptions = Seq("--no-fallback", "--initialize-at-build-time")
@@ -80,13 +86,8 @@ trait ScairModule extends ScalafixModule with SonatypeCentralPublishModule with 
       }
     }
 
-    object test extends ScoverageTests with TestModule.ScalaTest with ScairSettings {
+    object test extends ScoverageTests with ScairTests {
       override def moduleDir: Path = outer().test.moduleDir
-      override def mvnDeps = Seq(mvn"org.scalatest::scalatest:3.2.19")
-
-      // This was necessary to cooperate with graalvm at time of writing.
-      // Please remove if unit tests work fine without it in the future.
-      override def testParallelism = false
     }
   }
   
@@ -94,15 +95,7 @@ trait ScairModule extends ScalafixModule with SonatypeCentralPublishModule with 
 
   override def publishVersion = VcsVersion.vcsState().format(untaggedSuffix = "-SNAPSHOT")
 
-  object test extends ScoverageTests with TestModule.ScalaTest with ScairSettings{
-    // Revert that it is a ScoverageTests
-    override def runClasspath: Simple[Seq[PathRef]] = super[ScairSettings].runClasspath()
-
-    override def mvnDeps = Seq(mvn"org.scalatest::scalatest:3.2.19")
-    // This was necessary to cooperate with graalvm at time of writing.
-    // Please remove if unit tests work fine without it in the future.
-    override def testParallelism = false
-  }
+  object test extends ScairTests
 }
 
 object `package` extends ScairSettings with ScoverageReport with UnidocModule {

--- a/build.mill
+++ b/build.mill
@@ -22,6 +22,9 @@ import java.io.PrintWriter
 import os.Path
 import mill.api.Task.Simple
 import mill.scalalib.PlatformScalaModule
+import mill.scalanativelib.ScalaNativeModule
+import mill.scalanativelib.api.LTO
+import mill.scalanativelib.api.ReleaseMode
 
 trait ScairSettings extends ScalaModule {
   def scoverageVersion = Task{"2.3.0"}
@@ -35,7 +38,7 @@ trait ScairSettings extends ScalaModule {
 trait JvmScairModule extends ScalafixModule with PlatformScalaModule with SonatypeCentralPublishModule with ScoverageModule with ScairSettings {
 
   trait ScairTests extends ScalaTests with TestModule.ScalaTest {
-    override def mvnDeps = Seq(mvn"org.scalatest::scalatest:3.2.19")
+    override def mvnDeps = Seq(mvn"org.scalatest::scalatest::3.2.19")
     // This was necessary to cooperate with graalvm at time of writing.
     // Please remove if unit tests work fine without it in the future.
     override def testParallelism = false
@@ -100,6 +103,11 @@ trait GraalScairModule extends JvmScairModule with NativeImageModule {
   override def jvmId = "graalvm-community:24.0.1"
   override def nativeImageOptions = Seq("--no-fallback", "--initialize-at-build-time")
 }
+trait NativeScairModule extends JvmScairModule with ScalaNativeModule {
+  override def scalaNativeVersion = "0.5.8"
+  override def nativeLTO: Simple[LTO] = LTO.Full
+  override def releaseMode: Simple[ReleaseMode] = ReleaseMode.ReleaseFull
+}
 
 trait ScairModule extends ScairSettings {
   def agnosticModule = ModuleRef(this)
@@ -111,6 +119,11 @@ trait ScairModule extends ScairSettings {
 
   lazy val graal: GraalScairModule = new GraalScairModule {
     override def moduleDeps = agnosticModule().moduleDeps.map(_.graal)
+    override def mvnDeps = agnosticModule().mvnDeps
+  }
+
+  lazy val native: NativeScairModule = new NativeScairModule {
+    override def moduleDeps = agnosticModule().moduleDeps.map(_.native)
     override def mvnDeps = agnosticModule().mvnDeps
   }
 }
@@ -138,8 +151,8 @@ object `package` extends ScairSettings with ScoverageReport with UnidocModule {
     override def moduleDeps = Seq(utils)
 
     override def mvnDeps = Seq(
-      mvn"com.lihaoyi::fastparse:3.1.0",
-      mvn"com.github.scopt::scopt:4.1.0"
+      mvn"com.lihaoyi::fastparse::3.1.0",
+      mvn"com.github.scopt::scopt::4.1.0"
     )
   }
 
@@ -167,31 +180,31 @@ object `package` extends ScairSettings with ScoverageReport with UnidocModule {
     children ++ children.flatMap(child => allChidrenRec(child.moduleDirectChildren))
   }
 
-  def scalafixAll(args: String*) = Command(exclusive = true) {
+  def scalafixAll(args: String*) = Command {
     Task.sequence(allChildren
       .flatMap{case m : ScalafixModule => Some(m.fix(args*))
       case _ => None})()
     }
 
   // Run all formatting on all sources in the framework
-  def formatAll(evaluator: Evaluator) = Command(exclusive = true) {
+  def formatAll(evaluator: Evaluator) = Command {
     scalafixAll()()
     scalafmt.ScalafmtModule.reformatAll(allScalaSources(evaluator))()
   }
 
   // Run all formatting *checks* on all sources in the framework
-  def checkFormatAll(evaluator: Evaluator) = Command(exclusive = true) {
+  def checkFormatAll(evaluator: Evaluator) = Command {
     scalafixAll("--check")()
     scalafmt.ScalafmtModule.checkFormatAll(allScalaSources(evaluator))()
   }
 
   // Define a testAll to run the full framework testing infrastructure
-  def testAll(evaluator: Evaluator) = Command(exclusive = true) {
+  def testAll(evaluator: Evaluator) = Command {
     runAll("_.jvm.test", evaluator)()
     filechecks.run()()
   }
 
-  def scoverage(evaluator: Evaluator) = Command(exclusive = true) {
+  def scoverage(evaluator: Evaluator) = Command {
     runAll("_.jvm.scoverage.test", evaluator)()
     filechecks.scoverage.run()()
     xmlReportAll(evaluator)()
@@ -215,9 +228,14 @@ object `package` extends ScairSettings with ScoverageReport with UnidocModule {
     }
   }
   object filechecks extends filechecks:
-    override def scairOpt = tools.launcher
+    override def scairOpt = tools.jvm.launcher
+
     object scoverage extends filechecks:
       override def scairOpt = tools.jvm.scoverage.launcher
-    object nativeImage extends filechecks:
+
+    object graal extends filechecks:
       override def scairOpt = tools.graal.nativeImage
+
+    object native extends filechecks:
+      override def scairOpt = tools.native.nativeLink
 }


### PR DESCRIPTION
The biggest flaw right now is that it makes the CI take forever; I feel like this isn't a big issue for now and it definitely can be optimized later on, what do we think?

NB: This keeps the local testing as fast as with the recent fixes; it's just Scala Native compilation itself taking longer, especially on the slow CI nodes - which should be done in parallel to shorter feedback tests, coverage etc.