### PR TITLE
PatternRewriter quickfix

### DIFF
--- a/core/src/main/scala-3/transformations/PatternRewriter.scala
+++ b/core/src/main/scala-3/transformations/PatternRewriter.scala
@@ -146,13 +146,15 @@ trait Rewriter {
       )
     }
 
-    insert_ops_before(op, ops)
+    RewriteMethods.insert_ops_before(op, ops)
 
     for ((old_res, new_res) <- (op.results zip results)) {
       replace_value(old_res, new_res)
     }
 
-    erase_op(op, safe_erase = false)
+    RewriteMethods.erase_op(op, safe_erase = false)
+    operation_removal_handler(op)
+    ops.foreach(operation_insertion_handler)
   }
 
   def replace_value(


### PR DESCRIPTION
Another workaround in that questionnable bit of code, until we rethink it properly!

Current behaviour calls insertion handlers *then* the removal handler.
In cases where update an operation with a copy of itself and the same/updated body, this leads the nested operations to be removed from the worklist; this change enforce to handle the removal before the insertions, such that the nested operations would be removed then re-added to the worklist; far from great, but working!