### PR TITLE
Avoid ConstraintImpl instances at runtime

### DIFF
--- a/core/src/main/scala-3/clair/Definitions.scala
+++ b/core/src/main/scala-3/clair/Definitions.scala
@@ -1,7 +1,7 @@
 package scair.clair.codegen
 
 import scair.clair.macros.AssemblyFormatDirective
-import scair.core.constraints.ConstraintImpl
+import scair.core.constraints.Constraint
 
 import scala.quoted.*
 import scala.reflect.*
@@ -53,7 +53,7 @@ case class OperandDef(
     override val name: String,
     val tpe: Type[?],
     override val variadicity: Variadicity = Variadicity.Single,
-    val constraint: Option[Expr[ConstraintImpl[?]]] = None
+    val constraint: Option[Type[? <: Constraint]] = None
 ) extends OpInputDef
     with MayVariadicOpInputDef {}
 
@@ -61,7 +61,7 @@ case class ResultDef(
     override val name: String,
     val tpe: Type[?],
     override val variadicity: Variadicity = Variadicity.Single,
-    val constraint: Option[Expr[ConstraintImpl[?]]] = None
+    val constraint: Option[Type[? <: Constraint]] = None
 ) extends OpInputDef
     with MayVariadicOpInputDef {}
 
@@ -80,9 +80,8 @@ case class SuccessorDef(
 case class OpPropertyDef(
     override val name: String,
     val tpe: Type[?],
-    override val variadicity: Variadicity.Single.type |
-      Variadicity.Optional.type = Variadicity.Single,
-    val constraint: Option[Expr[ConstraintImpl[?]]] = None
+    override val variadicity: Variadicity = Variadicity.Single,
+    val constraint: Option[Type[? <: Constraint]] = None
 ) extends OpInputDef
     with MayVariadicOpInputDef {}
 

--- a/core/src/main/scala-3/clair/Macros.scala
+++ b/core/src/main/scala-3/clair/Macros.scala
@@ -8,6 +8,8 @@ import scair.Parser.*
 import scair.Printer
 import scair.clair.codegen.*
 import scair.clair.mirrored.*
+import scair.core.constraints.Constraint
+import scair.core.constraints.ConstraintVerifier
 import scair.dialects.builtin.*
 import scair.ir.*
 import scair.scairdl.constraints.*
@@ -15,6 +17,7 @@ import scair.transformations.CanonicalizationPatterns
 import scair.transformations.RewritePattern
 
 import scala.annotation.switch
+import scala.compiletime.summonInline
 import scala.quoted.*
 
 // ░█████╗░ ██╗░░░░░ ░█████╗░ ██╗ ██████╗░ ██╗░░░██╗ ██████╗░
@@ -220,9 +223,12 @@ def verifyMacro(
     .collect(_ match
       case OperandDef(name, _, _, Some(constraint)) =>
         val mem = selectMember[Operand[Attribute]](adtOpExpr, name)
-        '{ (ctx: scair.core.constraints.ConstraintContext) =>
-          $constraint.verify($mem.typ)(using ctx)
-        })
+        constraint match
+          case '[type t <: Constraint; `t`] =>
+
+            '{ (ctx: scair.core.constraints.ConstraintContext) =>
+              summonInline[ConstraintVerifier[t]]($mem.typ)(ctx)
+            })
 
   '{
     given ctx: scair.core.constraints.ConstraintContext =
@@ -840,6 +846,8 @@ def deriveOperationCompanion[T <: Operation: Type](using
       '{ $canonicalizationPatterns.patterns }
     case None => '{ Seq() }
 
+  val verify = '{ (adtOp: T) => ${ verifyMacro(opDef, '{ adtOp }) } }
+
   '{
 
     new DerivedOperationCompanion[T]:
@@ -864,9 +872,7 @@ def deriveOperationCompanion[T <: Operation: Type](using
         ${ customPrintMacro(opDef, '{ adtOp }, '{ p }, '{ indentLevel }) }
 
       def constraint_verify(adtOp: T): Either[String, Operation] =
-        ${
-          verifyMacro(opDef, '{ adtOp })
-        }
+        $verify(adtOp)
 
       override def parse[$: P as ctx](
           p: Parser,

--- a/core/src/main/scala-3/clair/Macros.scala
+++ b/core/src/main/scala-3/clair/Macros.scala
@@ -846,8 +846,6 @@ def deriveOperationCompanion[T <: Operation: Type](using
       '{ $canonicalizationPatterns.patterns }
     case None => '{ Seq() }
 
-  val verify = '{ (adtOp: T) => ${ verifyMacro(opDef, '{ adtOp }) } }
-
   '{
 
     new DerivedOperationCompanion[T]:
@@ -872,7 +870,9 @@ def deriveOperationCompanion[T <: Operation: Type](using
         ${ customPrintMacro(opDef, '{ adtOp }, '{ p }, '{ indentLevel }) }
 
       def constraint_verify(adtOp: T): Either[String, Operation] =
-        $verify(adtOp)
+        ${
+          verifyMacro(opDef, '{ adtOp })
+        }
 
       override def parse[$: P as ctx](
           p: Parser,

--- a/core/src/main/scala-3/clair/Mirror.scala
+++ b/core/src/main/scala-3/clair/Mirror.scala
@@ -37,16 +37,7 @@ def getTypeConstraint(tpe: Type[?])(using Quotes) =
     case AppliedType(op, List(attr, constraint)) =>
       constraint.asType match
         case '[type t <: Constraint; `t`] =>
-          Expr.summon[ConstraintImpl[t]] match
-            case Some(i) => Some(i)
-            case None    =>
-              Implicits.search(TypeRepr.of[ConstraintImpl[t]]) match
-                case s: ImplicitSearchSuccess =>
-                  Some(s.tree.asExprOf[ConstraintImpl[t]])
-                case f: ImplicitSearchFailure =>
-                  report.errorAndAbort(
-                    s"Could not find an implementation for constraint ${Type.show[t]}:\n${f.explanation}"
-                  )
+          Some(Type.of[t])
     case _ =>
       None
 


### PR DESCRIPTION
This enables inlining the verifiers in the generated code! One step towards actual macro compositions there.

In practice, for the example (in our tests) of:
```scala
val f32 = Float32Type()

case class MulFEq(
    lhs: Operand[FloatType !> EqAttr[f32.type]],
    rhs: Operand[FloatType !> EqAttr[f32.type]],
    result: Result[FloatType]
) extends DerivedOperation["cmath.mul", MulFEq]
```

The current code to enforce `lhs`'s constraint is:
```java
         0: aload_1
         1: invokestatic  #461                // Method ctx$1:(Lscala/runtime/LazyRef;)Lscair/core/constraints/ConstraintContext;
         4: astore_3
         5: getstatic     #466                // Field scair/MacroConstraintsTest$package$.MODULE$:Lscair/MacroConstraintsTest$package$;
         8: invokevirtual #470                // Method scair/MacroConstraintsTest$package$.f32:()Lscair/dialects/builtin/Float32Type;
        11: astore        4
        13: new           #472                // class scair/core/constraints/ConstraintImplEqAttr
        16: dup
        17: aload         4
        19: invokespecial #475                // Method scair/core/constraints/ConstraintImplEqAttr."<init>":(Lscair/ir/Attribute;)V
        22: aload_0
        23: invokevirtual #391                // Method lhs:()Lscair/ir/Value;
        26: invokevirtual #481                // Method scair/ir/Value.typ:()Lscair/ir/Attribute;
        29: aload_3
        30: invokevirtual #484                // Method scair/core/constraints/ConstraintImplEqAttr.verify:(Lscair/ir/Attribute;Lscair/core/constraints/ConstraintContext;)Lscala/util/Either;
        33: areturn
```
And with this change is:
```java
         0: aload_1
         1: invokestatic  #461                // Method ctx$1:(Lscala/runtime/LazyRef;)Lscair/core/constraints/ConstraintContext;
         4: astore_3
         5: aload_0
         6: invokevirtual #391                // Method lhs:()Lscair/ir/Value;
         9: invokevirtual #467                // Method scair/ir/Value.typ:()Lscair/ir/Attribute;
        12: checkcast     #469                // class scair/dialects/builtin/FloatType
        15: astore        4
        17: getstatic     #474                // Field scair/MacroConstraintsTest$package$.MODULE$:Lscair/MacroConstraintsTest$package$;
        20: invokevirtual #478                // Method scair/MacroConstraintsTest$package$.f32:()Lscair/dialects/builtin/Float32Type;
        23: astore        5
        25: aload         4
        27: aload         5
        29: astore        6
        31: dup
        32: ifnonnull     44
        35: pop
        36: aload         6
        38: ifnull        52
```
Emphasis:
- No `ConstraintImpl` initialization and virtual invocation left, just code comparing `lhs` to `f32`