### PR TITLE
Refactor UnregisteredOperation and current usages.

### DIFF
--- a/core/src/main/scala-3/MLContext.scala
+++ b/core/src/main/scala-3/MLContext.scala
@@ -28,9 +28,19 @@ class MLContext():
   val dialectAttrContext: mutable.Map[String, AttributeCompanion[?]] =
     mutable.Map()
 
-  def getOperation(name: String) = dialectOpContext.get(name)
+  def getOpCompanion(
+      name: String,
+      allowUnregisteredDialect: Boolean = false
+  ) = dialectOpContext.get(name) match
+    case Some(companion) => Right(companion)
+    case None            =>
+      if allowUnregisteredDialect then Right(UnregisteredOperation(name))
+      else
+        Left(
+          s"Operation ${name} is not registered. If this is intended, use `--allow-unregistered-dialect`."
+        )
 
-  def getAttribute(name: String) = dialectAttrContext.get(name)
+  def getAttrCompanion(name: String) = dialectAttrContext.get(name)
 
   def registerDialect(dialect: Dialect) =
     dialectOpContext ++= {

--- a/core/src/main/scala-3/builtin/AttrParser.scala
+++ b/core/src/main/scala-3/builtin/AttrParser.scala
@@ -71,7 +71,7 @@ class AttrParser(
   def DialectAttribute[$: P]: P[Attribute] = P(
     "#" ~~ PrettyDialectReferenceName.flatMapTry {
       (dialect: String, attrName: String) =>
-        ctx.getAttribute(s"${dialect}.${attrName}") match
+        ctx.getAttrCompanion(s"${dialect}.${attrName}") match
           case Some(attr) =>
             attr.parse(this)
           case None =>
@@ -84,7 +84,7 @@ class AttrParser(
   def DialectType[$: P]: P[Attribute] = P(
     "!" ~~ PrettyDialectReferenceName.flatMapTry {
       (dialect: String, attrName: String) =>
-        ctx.getAttribute(s"${dialect}.${attrName}") match
+        ctx.getAttrCompanion(s"${dialect}.${attrName}") match
           case Some(attr) =>
             attr.parse(this)
           case None =>

--- a/core/src/main/scala-3/ir/Operation.scala
+++ b/core/src/main/scala-3/ir/Operation.scala
@@ -152,7 +152,32 @@ trait Operation extends IRNode with IntrusiveNode[Operation]:
   final override def hashCode(): Int = System.identityHashCode(this)
   final override def equals(o: Any): Boolean = this eq o.asInstanceOf[Object]
 
-case class UnregisteredOperation(
+object UnregisteredOperation:
+
+  def apply(_name: String) =
+    new OperationCompanion[UnregisteredOperation]:
+      override def name = _name
+
+      def apply(
+          operands: Seq[Value[Attribute]] = Seq(),
+          successors: Seq[Block] = Seq(),
+          results: Seq[Result[Attribute]] = Seq(),
+          regions: Seq[Region] = Seq(),
+          properties: Map[String, Attribute] = Map.empty[String, Attribute],
+          attributes: DictType[String, Attribute] =
+            DictType.empty[String, Attribute]
+      ): UnregisteredOperation =
+        new UnregisteredOperation(
+          name = _name,
+          operands = operands,
+          successors = successors,
+          results = results,
+          regions = regions,
+          properties = properties,
+          attributes = attributes
+        )
+
+case class UnregisteredOperation private (
     override val name: String,
     override val operands: Seq[Value[Attribute]] = Seq(),
     override val successors: Seq[Block] = Seq(),
@@ -172,8 +197,7 @@ case class UnregisteredOperation(
       properties: Map[String, Attribute] = properties,
       attributes: DictType[String, Attribute] = attributes
   ) =
-    UnregisteredOperation(
-      name = name,
+    UnregisteredOperation(name)(
       operands = operands,
       successors = successors,
       results = results,
@@ -186,7 +210,7 @@ trait OperationCompanion[O <: Operation]:
   def name: String
 
   def parse[$: P](parser: Parser, resNames: Seq[String]): P[O] =
-    throw new Exception(
+    fastparse.Fail(
       s"No custom Parser implemented for Operation '${name}'"
     )
 

--- a/core/test/src/scala-3/AttrParserTest.scala
+++ b/core/test/src/scala-3/AttrParserTest.scala
@@ -132,8 +132,7 @@ class AttrParserTest extends AnyFlatSpec with BeforeAndAfter:
   val valINDEX = Value[Attribute](INDEX)
 
   "printDataibutesWithinOp" should "return the correct string representation of a Operation with blocks and different attributes" in {
-    val op = UnregisteredOperation(
-      "test.op",
+    val op = UnregisteredOperation("test.op")(
       results = Seq(
         F32,
         F64,
@@ -144,14 +143,12 @@ class AttrParserTest extends AnyFlatSpec with BeforeAndAfter:
       ListType(F128),
       ListType(
         op,
-        UnregisteredOperation(
-          "test.op",
+        UnregisteredOperation("test.op")(
           operands = Seq(op.results(1), op.results(0))
         )
       )
     )
-    val op2 = UnregisteredOperation(
-      "test.op",
+    val op2 = UnregisteredOperation("test.op")(
       successors = Seq(block1),
       results = Seq(
         I1,
@@ -163,8 +160,7 @@ class AttrParserTest extends AnyFlatSpec with BeforeAndAfter:
       ListType(I32),
       ListType(
         op2,
-        UnregisteredOperation(
-          "test.op",
+        UnregisteredOperation("test.op")(
           operands = Seq(
             op2.results(1),
             op2.results(0)
@@ -172,8 +168,7 @@ class AttrParserTest extends AnyFlatSpec with BeforeAndAfter:
         )
       )
     )
-    val op3 = UnregisteredOperation(
-      "test.op",
+    val op3 = UnregisteredOperation("test.op")(
       results = Seq(
         INDEX
       ).map(Result(_))
@@ -182,16 +177,14 @@ class AttrParserTest extends AnyFlatSpec with BeforeAndAfter:
       ListType(I64),
       ListType(
         op3,
-        UnregisteredOperation(
-          "test.op",
+        UnregisteredOperation("test.op")(
           operands = Seq(op3.results(0))
         )
       )
     )
 
     val program =
-      UnregisteredOperation(
-        "op1",
+      UnregisteredOperation("op1")(
         regions = Seq(
           Region(
             Seq(
@@ -225,23 +218,20 @@ class AttrParserTest extends AnyFlatSpec with BeforeAndAfter:
     val block1 = new Block(
       ListType(F16),
       ListType(
-        UnregisteredOperation(
-          "test.op",
+        UnregisteredOperation("test.op")(
           operands = Seq(
             valF32,
             valF64,
             Value(F80)
           )
         ),
-        UnregisteredOperation(
-          "test.op",
+        UnregisteredOperation("test.op")(
           Seq(valF64, valF32)
         )
       )
     )
 
-    val op4 = UnregisteredOperation(
-      "test.op",
+    val op4 = UnregisteredOperation("test.op")(
       successors = Seq(block1),
       results = Seq(
         I1,
@@ -254,8 +244,7 @@ class AttrParserTest extends AnyFlatSpec with BeforeAndAfter:
       ListType(F128),
       ListType(
         op4,
-        UnregisteredOperation(
-          "test.op",
+        UnregisteredOperation("test.op")(
           operands = Seq(
             op4.results(1),
             op4.results(0)
@@ -264,8 +253,7 @@ class AttrParserTest extends AnyFlatSpec with BeforeAndAfter:
       )
     )
 
-    val op5 = UnregisteredOperation(
-      "test.op",
+    val op5 = UnregisteredOperation("test.op")(
       results = Seq(
         INDEX
       ).map(Result(_))
@@ -275,16 +263,14 @@ class AttrParserTest extends AnyFlatSpec with BeforeAndAfter:
       ListType(I64),
       ListType(
         op5,
-        UnregisteredOperation(
-          "test.op",
+        UnregisteredOperation("test.op")(
           operands = Seq(op5.results(0))
         )
       )
     )
 
     val program =
-      UnregisteredOperation(
-        "op1",
+      UnregisteredOperation("op1")(
         regions = Seq(
           Region(
             Seq(

--- a/core/test/src/scala-3/ParserTest.scala
+++ b/core/test/src/scala-3/ParserTest.scala
@@ -346,14 +346,13 @@ class ParserTest
                  |  }) : () -> ()""".stripMargin
 
       val bb4 = Block(
-        ListType(UnregisteredOperation("test.op"))
+        ListType(UnregisteredOperation("test.op")())
       )
       val bb3 = Block(
-        ListType(UnregisteredOperation("test.op", successors = Seq(bb4)))
+        ListType(UnregisteredOperation("test.op")(successors = Seq(bb4)))
       )
       val operation =
-        UnregisteredOperation(
-          "test.op",
+        UnregisteredOperation("test.op")(
           regions = Seq(Region(bb3, bb4))
         )
 

--- a/core/test/src/scala-3/PrinterTest.scala
+++ b/core/test/src/scala-3/PrinterTest.scala
@@ -27,7 +27,7 @@ class PrinterTest extends AnyFlatSpec with BeforeAndAfter:
   "printRegion" should "return the correct string representation of a region" in {
     val region =
       Region(
-        Seq(Block(ListType(UnregisteredOperation("op1"))))
+        Seq(Block(ListType(UnregisteredOperation("op1")())))
       )
     val expected = """{
                      |  "op1"() : () -> ()
@@ -40,7 +40,7 @@ class PrinterTest extends AnyFlatSpec with BeforeAndAfter:
   "printBlock" should "return the correct string representation of a block" in {
     val block = Block(
       Seq(I32),
-      Seq(UnregisteredOperation("op1"))
+      Seq(UnregisteredOperation("op1")())
     )
     val expected = """^bb0(%0: i32):
                      |  "op1"() : () -> ()
@@ -69,15 +69,14 @@ class PrinterTest extends AnyFlatSpec with BeforeAndAfter:
   }
 
   "printOperation" should "return the correct string representation of an operation" in {
-    val operation = UnregisteredOperation(
-      "op1",
+    val operation = UnregisteredOperation("op1")(
       results = Seq(Result(F32)),
       operands = Seq(Value(F32)),
       regions = Seq(
         Region(
           Seq(
             Block(
-              ListType(UnregisteredOperation("op2"))
+              ListType(UnregisteredOperation("op2")())
             )
           )
         )
@@ -105,16 +104,14 @@ class PrinterTest extends AnyFlatSpec with BeforeAndAfter:
     )
 
     val program =
-      UnregisteredOperation(
-        "op1",
+      UnregisteredOperation("op1")(
         regions = Seq(
           Region(
             Seq(
               successorTestBlock,
               Block(
                 Seq(
-                  UnregisteredOperation(
-                    "test.op",
+                  UnregisteredOperation("test.op")(
                     successors = Seq(successorTestBlock)
                   )
                 )

--- a/dialects/test/src/scala-3/ArithTest.scala
+++ b/dialects/test/src/scala-3/ArithTest.scala
@@ -22,10 +22,9 @@ class ArithTests extends AnyFlatSpec with BeforeAndAfter:
   given indentLevel: Int = 0
 
   "Such real ADT manipulation" should "flex how working it is" in {
-    val zero = UnregisteredOperation(
-      name = "arith.constant",
-      results = Seq(Result(I32)),
-      properties = Map("value" -> IntegerAttr(IntData(0), I32))
+    val zero = Constant(
+      IntegerAttr(IntData(0), I32),
+      Result(I32)
     )
     val module = ModuleOp(
       Region(

--- a/passes/src/main/scala-3/CMathDummyTransformation.scala
+++ b/passes/src/main/scala-3/CMathDummyTransformation.scala
@@ -19,10 +19,10 @@ val TestInsertingDummyOperation = pattern {
 
   case op if (op.name == "tobereplaced") && (op.results.length == 0) =>
     Seq(
-      UnregisteredOperation("dummy1"),
-      UnregisteredOperation("dummy2"),
-      UnregisteredOperation("dummy3"),
-      UnregisteredOperation("dummy4")
+      UnregisteredOperation("dummy1")(),
+      UnregisteredOperation("dummy2")(),
+      UnregisteredOperation("dummy3")(),
+      UnregisteredOperation("dummy4")()
     )
   case op
       if (!op.attributes.contains("replaced")) && op.container_block != None =>
@@ -34,18 +34,17 @@ val TestInsertingDummyOperation = pattern {
 val TestReplacingDummyOperation = pattern {
   case op if (op.name == "tobereplaced") =>
     val op1 =
-      UnregisteredOperation("dummy-op1")
+      UnregisteredOperation("dummy-op1")()
 
     val op2 =
-      UnregisteredOperation("dummy-op2")
+      UnregisteredOperation("dummy-op2")()
 
     val op3 =
       UnregisteredOperation(
         "dummy-return"
-      )
+      )()
 
-    UnregisteredOperation(
-      "replacedOp",
+    UnregisteredOperation("replacedOp")(
       regions = Seq(Region(Block(operations = Seq(op1, op2, op3)))),
       results = Seq(StringData("replaced(i32)"), StringData("replaced(i64)"))
         .map(Result(_))


### PR DESCRIPTION
We currently special case on every use site.
This PR offers a slight rework of UnregisteredOperation and the MLContext API, so that the user let MLContext know if unregistered dialects are allowed, so that if needed, you will receive a standard OperationCompanion transparently. I find it clearer?

On UnregisteredOperation's side, now the name is to be passed in a first parameter list, which actually returns an `OperationCompanion[UnregisteredOperation]`, implementing the right name and `apply`.

It helped working on something else, opening this to keep the bigger PR on-point :slightly_smiling_face: 