### PR TITLE
`main` fix

### DIFF
--- a/core/src/main/scala-3/clair/package.scala
+++ b/core/src/main/scala-3/clair/package.scala
@@ -56,8 +56,7 @@ package scair
   * case class SampleType(
   *     val value: FloatType
   * ) extends DerivedAttribute["sample.sample_type", SampleType]
-  *     with TypeAttribute
-  *     derives DerivedAttributeCompanion
+  *     with TypeAttribute derives DerivedAttributeCompanion
   *
   * /*≡≡=---=≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡=---=≡≡*\
   * ||   defining custom operations   ||


### PR DESCRIPTION
Went a bit fast and broke `main`

Turns out even our documentation snippets are autoformatted :yum: 