### PR TITLE
Error monad

### DIFF
--- a/core/src/main/scala-3/Constraints.scala
+++ b/core/src/main/scala-3/Constraints.scala
@@ -1,7 +1,7 @@
 package scair.core.constraints
 
 import scair.ir.*
-import scair.utils.R
+import scair.utils.OK
 
 import scala.compiletime.constValue
 import scala.quoted.*
@@ -28,7 +28,7 @@ trait ConstraintImpl[c <: Constraint]:
 
   def verify(attr: Attribute)(using
       ctx: ConstraintContext
-  ): R[Unit]
+  ): OK[Unit]
 
 infix type !>[A <: Attribute, C <: Constraint] = A
 
@@ -52,7 +52,7 @@ class ConstraintImplEqAttr[To <: Attribute](ref: To)
 
   override def verify(attr: Attribute)(using
       ctx: ConstraintContext
-  ): R[Unit] =
+  ): OK[Unit] =
     if attr == ref then Right(())
     else Left(s"Expected $ref, got $attr")
 
@@ -64,7 +64,7 @@ class ConstraintImplVar[To <: String](name: To) extends ConstraintImpl[Var[To]]:
 
   override def verify(attr: Attribute)(using
       ctx: ConstraintContext
-  ): R[Unit] =
+  ): OK[Unit] =
     if ctx.varConstraints.contains(name) then
       if ctx.varConstraints.apply(name) != attr then
         Left(s"Expected ${ctx.varConstraints.apply(name)}, got $attr")

--- a/core/src/main/scala-3/builtin/Builtin.scala
+++ b/core/src/main/scala-3/builtin/Builtin.scala
@@ -8,7 +8,7 @@ import scair.core.macros.*
 import scair.dialects.affine.AffineMap
 import scair.dialects.affine.AffineSet
 import scair.ir.*
-import scair.utils.R
+import scair.utils.OK
 
 // ██████╗░ ██╗░░░██╗ ██╗ ██╗░░░░░ ████████╗ ██╗ ███╗░░██╗
 // ██╔══██╗ ██║░░░██║ ██║ ██║░░░░░ ╚══██╔══╝ ██║ ████╗░██║
@@ -375,7 +375,7 @@ final case class DenseArrayAttr(
   override def name: String = "builtin.dense_array"
   override def parameters: Seq[Attribute | Seq[Attribute]] = Seq(typ, data)
 
-  override def customVerify(): R[Unit] =
+  override def customVerify(): OK[Unit] =
     if !data.forall(_ match
         case IntegerAttr(_, eltyp) => eltyp == typ
         case FloatAttr(_, eltyp)   => eltyp == typ)
@@ -439,7 +439,7 @@ final case class DenseIntOrFPElementsAttr(
 
   def elementType = typ.elementType
 
-  override def customVerify(): R[Unit] =
+  override def customVerify(): OK[Unit] =
     val tpe = elementType match
       case it: IntegerType => Right(it)
       case ft: FloatType   => Right(ft)
@@ -448,7 +448,7 @@ final case class DenseIntOrFPElementsAttr(
           s"DenseIntOrFPElementsAttr element type must be IntegerType or FloatType, got: $elementType"
         )
 
-    data.attrValues.foldLeft[R[Any]](
+    data.attrValues.foldLeft[OK[Any]](
       tpe
     )((acc, elt) =>
       acc.map(tpe =>

--- a/core/src/main/scala-3/clair/Macros.scala
+++ b/core/src/main/scala-3/clair/Macros.scala
@@ -13,7 +13,7 @@ import scair.enums.macros.*
 import scair.ir.*
 import scair.transformations.CanonicalizationPatterns
 import scair.transformations.RewritePattern
-import scair.utils.R
+import scair.utils.OK
 
 import scala.annotation.switch
 import scala.quoted.*
@@ -215,9 +215,9 @@ def parseMacro[O <: Operation: Type](
 def verifyMacro(
     opDef: OperationDef,
     adtOpExpr: Expr[?],
-)(using Quotes): Expr[R[Operation]] =
+)(using Quotes): Expr[OK[Operation]] =
 
-  val a = opDef.operands // val xyz: Seq[Expr[R[Unit]]] =
+  val a = opDef.operands // val xyz: Seq[Expr[OK[Unit]]] =
     .filter(_.variadicity == Variadicity.Single)
     .collect(_ match
       case OperandDef(name, _, _, Some(constraint)) =>
@@ -230,7 +230,7 @@ def verifyMacro(
     given ctx: scair.core.constraints.ConstraintContext =
       scair.core.constraints.ConstraintContext()
     ${
-      val chain = a.foldLeft[Expr[R[Unit]]](
+      val chain = a.foldLeft[Expr[OK[Unit]]](
         '{ Right(()) }
       )((res, result) => '{ $res.flatMap(_ => $result(ctx)) })
       '{ $chain.map(_ => $adtOpExpr.asInstanceOf[Operation]) }
@@ -867,7 +867,7 @@ def deriveOperationCompanion[T <: Operation: Type](using
       def customPrint(adtOp: T, p: Printer)(using indentLevel: Int): Unit =
         ${ customPrintMacro(opDef, '{ adtOp }, '{ p }, '{ indentLevel }) }
 
-      def constraintVerify(adtOp: T): R[Operation] =
+      def constraintVerify(adtOp: T): OK[Operation] =
         ${
           verifyMacro(opDef, '{ adtOp })
         }

--- a/core/src/main/scala-3/clair/Traits.scala
+++ b/core/src/main/scala-3/clair/Traits.scala
@@ -2,7 +2,7 @@ package scair.clair.macros
 
 import scair.Printer
 import scair.ir.*
-import scair.utils.R
+import scair.utils.OK
 
 // ████████╗ ██████╗░ ░█████╗░ ██╗ ████████╗ ░██████╗
 // ╚══██╔══╝ ██╔══██╗ ██╔══██╗ ██║ ╚══██╔══╝ ██╔════╝
@@ -57,8 +57,8 @@ abstract class DerivedOperation[name <: String, T <: Operation](using
   override def customPrint(p: Printer)(using indentLevel: Int): Unit =
     comp.customPrint(this, p)
 
-  override def verify(): R[Operation] =
+  override def verify(): OK[Operation] =
     super.verify().flatMap(_ => constraintVerify())
 
-  def constraintVerify(): R[Operation] =
+  def constraintVerify(): OK[Operation] =
     comp.constraintVerify(this)

--- a/core/src/main/scala-3/clair/TypeClasses.scala
+++ b/core/src/main/scala-3/clair/TypeClasses.scala
@@ -4,7 +4,7 @@ import fastparse.ParsingRun
 import scair.AttrParser
 import scair.Printer
 import scair.ir.*
-import scair.utils.R
+import scair.utils.OK
 
 import scala.quoted.*
 import scala.util.Failure
@@ -45,7 +45,7 @@ trait DerivedOperationCompanion[T <: Operation] extends OperationCompanion[T]:
   def regions(adtOp: T): Seq[Region]
   def properties(adtOp: T): Map[String, Attribute]
   def customPrint(adtOp: T, p: Printer)(using indentLevel: Int): Unit
-  def constraintVerify(adtOp: T): R[Operation]
+  def constraintVerify(adtOp: T): OK[Operation]
 
   case class UnstructuredOp(
       override val operands: Seq[Value[Attribute]] = Seq(),
@@ -79,7 +79,7 @@ trait DerivedOperationCompanion[T <: Operation] extends OperationCompanion[T]:
       case Failure(e)  => Left(e.toString())
       case Success(op) => op.asInstanceOf[Operation].structured
 
-    override def verify(): R[Operation] =
+    override def verify(): OK[Operation] =
       structured.flatMap(op => op.verify())
 
     override def name = companion.name

--- a/core/src/main/scala-3/ir/Attribute.scala
+++ b/core/src/main/scala-3/ir/Attribute.scala
@@ -4,7 +4,7 @@ import fastparse.*
 import scair.AttrParser
 import scair.Printer
 import scair.dialects.builtin.IntegerAttr
-import scair.utils.R
+import scair.utils.OK
 
 import java.io.PrintWriter
 import java.io.StringWriter
@@ -25,7 +25,7 @@ import java.io.StringWriter
 sealed trait Attribute:
   def name: String
   def prefix: String = "#"
-  def customVerify(): R[Unit] = Right(())
+  def customVerify(): OK[Unit] = Right(())
   def printParameters(p: Printer): Unit
 
   def customPrint(p: Printer): Unit =

--- a/core/src/main/scala-3/ir/Block.scala
+++ b/core/src/main/scala-3/ir/Block.scala
@@ -1,6 +1,6 @@
 package scair.ir
 
-import scair.utils.R
+import scair.utils.OK
 
 import scala.collection.mutable
 
@@ -276,8 +276,8 @@ case class Block private (
     detachOp(op)
     op.erase(safeErase)
 
-  def structured: R[Unit] =
-    operations.foldLeft[R[Unit]](Right(()))((res, op) =>
+  def structured: OK[Unit] =
+    operations.foldLeft[OK[Unit]](Right(()))((res, op) =>
       res.flatMap(_ =>
         op.structured.map(v =>
           operations(op) = v
@@ -286,11 +286,11 @@ case class Block private (
       )
     )
 
-  def verify(): R[Unit] =
-    arguments.foldLeft[R[Unit]](Right(()))((res, arg) =>
+  def verify(): OK[Unit] =
+    arguments.foldLeft[OK[Unit]](Right(()))((res, arg) =>
       res.flatMap(_ => arg.verify())
     ).flatMap(_ =>
-      operations.foldLeft[R[Unit]](Right(()))((res, op) =>
+      operations.foldLeft[OK[Unit]](Right(()))((res, op) =>
         res.flatMap(_ => op.verify().map(_ => ()))
       )
     )

--- a/core/src/main/scala-3/ir/Operation.scala
+++ b/core/src/main/scala-3/ir/Operation.scala
@@ -5,7 +5,7 @@ import scair.Parser
 import scair.Printer
 import scair.transformations.RewritePattern
 import scair.utils.IntrusiveNode
-import scair.utils.R
+import scair.utils.OK
 
 import scala.collection.mutable
 import scala.collection.mutable.LinkedHashMap
@@ -87,30 +87,30 @@ trait Operation extends IRNode with IntrusiveNode[Operation]:
   def properties: Map[String, Attribute]
   val attributes: DictType[String, Attribute] = DictType.empty
   var containerBlock: Option[Block] = None
-  def traitVerify(): R[Operation] = Right(this)
+  def traitVerify(): OK[Operation] = Right(this)
 
   def customPrint(p: Printer)(using indentLevel: Int) =
     p.printGenericMLIROperation(this)
 
-  def customVerify(): R[Operation] = Right(this)
+  def customVerify(): OK[Operation] = Right(this)
 
-  def structured: R[Operation] = regions.foldLeft[R[Unit]](Right(()))(
+  def structured: OK[Operation] = regions.foldLeft[OK[Unit]](Right(()))(
     (res, reg) => res.flatMap(_ => reg.structured)
   ).map(_ => this)
 
-  def verify(): R[Operation] =
-    results.foldLeft[R[Unit]](Right(()))((res, result) =>
+  def verify(): OK[Operation] =
+    results.foldLeft[OK[Unit]](Right(()))((res, result) =>
       res.flatMap(_ => result.verify())
     ).flatMap(_ =>
-      regions.foldLeft[R[Unit]](Right(()))((res, region) =>
+      regions.foldLeft[OK[Unit]](Right(()))((res, region) =>
         res.flatMap(_ => region.verify())
       )
     ).flatMap(_ =>
-      properties.values.toSeq.foldLeft[R[Unit]](Right(()))((res, prop) =>
+      properties.values.toSeq.foldLeft[OK[Unit]](Right(()))((res, prop) =>
         res.flatMap(_ => prop.customVerify())
       )
     ).flatMap(_ =>
-      attributes.values.toSeq.foldLeft[R[Unit]](Right(()))((res, attr) =>
+      attributes.values.toSeq.foldLeft[OK[Unit]](Right(()))((res, attr) =>
         res.flatMap(_ => attr.customVerify())
       )
     ).flatMap(_ => traitVerify()).flatMap(_ => customVerify())

--- a/core/src/main/scala-3/ir/Region.scala
+++ b/core/src/main/scala-3/ir/Region.scala
@@ -1,6 +1,6 @@
 package scair.ir
 
-import scair.utils.R
+import scair.utils.OK
 
 import scala.annotation.targetName
 import scala.collection.mutable
@@ -47,12 +47,12 @@ case class Region(
   blocks.foreach(attachBlock)
 
   def structured =
-    blocks.foldLeft[R[Unit]](Right(()))((res, block) =>
+    blocks.foldLeft[OK[Unit]](Right(()))((res, block) =>
       res.flatMap(_ => block.structured)
     )
 
-  def verify(): R[Unit] =
-    blocks.foldLeft[R[Unit]](Right(()))((res, block) =>
+  def verify(): OK[Unit] =
+    blocks.foldLeft[OK[Unit]](Right(()))((res, block) =>
       res.flatMap(_ => block.verify())
     )
 

--- a/core/src/main/scala-3/ir/Traits.scala
+++ b/core/src/main/scala-3/ir/Traits.scala
@@ -1,6 +1,6 @@
 package scair.ir
 
-import scair.utils.R
+import scair.utils.OK
 
 // ████████╗ ██████╗░ ░█████╗░ ██╗ ████████╗ ░██████╗
 // ╚══██╔══╝ ██╔══██╗ ██╔══██╗ ██║ ╚══██╔══╝ ██╔════╝
@@ -15,7 +15,7 @@ import scair.utils.R
 
 trait IsTerminator extends Operation:
 
-  override def traitVerify(): R[Operation] = {
+  override def traitVerify(): OK[Operation] = {
     this.containerBlock match
       case Some(b) =>
         if this ne b.operations.last then
@@ -35,7 +35,7 @@ trait IsTerminator extends Operation:
 
 trait NoTerminator extends Operation:
 
-  override def traitVerify(): R[Operation] = {
+  override def traitVerify(): OK[Operation] = {
     if regions.filter(x => x.blocks.length != 1).length != 0 then
       Left(
         s"NoTerminator Operation '$name' requires single-block regions"
@@ -47,12 +47,12 @@ trait NoMemoryEffect extends Operation
 
 trait IsolatedFromAbove extends Operation:
 
-  final def verifyRec(regs: Seq[Region]): R[Operation] =
+  final def verifyRec(regs: Seq[Region]): OK[Operation] =
     val r = regs match
       case region :: tail =>
-        region.blocks.foldLeft[R[Operation]](Right(this))((r, block) =>
+        region.blocks.foldLeft[OK[Operation]](Right(this))((r, block) =>
           r.flatMap(_ =>
-            block.operations.foldLeft[R[Operation]](r)((r, op) =>
+            block.operations.foldLeft[OK[Operation]](r)((r, op) =>
               op.operands.foldLeft(r)((r, o) =>
                 if !this
                     .isAncestor(
@@ -72,7 +72,7 @@ trait IsolatedFromAbove extends Operation:
       case Nil => Right(this)
     r.flatMap(_ => super.traitVerify())
 
-  override def traitVerify(): R[Operation] =
+  override def traitVerify(): OK[Operation] =
     verifyRec(regions)
 
 trait Commutative extends Operation

--- a/core/src/main/scala-3/ir/Value.scala
+++ b/core/src/main/scala-3/ir/Value.scala
@@ -1,7 +1,7 @@
 package scair.ir
 
 import scair.ir.*
-import scair.utils.R
+import scair.utils.OK
 
 //
 // ██╗░░░██╗ ░█████╗░ ██╗░░░░░ ██╗░░░██╗ ███████╗
@@ -33,7 +33,7 @@ final case class Value[+T <: Attribute](
         "Attempting to erase a Value that has uses in other operations."
       )
 
-  def verify(): R[Unit] = typ.customVerify()
+  def verify(): OK[Unit] = typ.customVerify()
 
   override final def equals(o: Any): Boolean =
     return this eq o.asInstanceOf[AnyRef]

--- a/dialects/src/main/scala-3/arith/Arith.scala
+++ b/dialects/src/main/scala-3/arith/Arith.scala
@@ -9,7 +9,7 @@ import scair.dialects.arith.canonicalization.given
 import scair.dialects.builtin.*
 import scair.enums.enumattr.*
 import scair.ir.*
-import scair.utils.R
+import scair.utils.OK
 
 import scala.collection.immutable.*
 
@@ -183,7 +183,7 @@ type IndexCastTypeConstraint = AnyIntegerType | MemrefType
 
 trait SameOperandsAndResultTypes extends Operation:
 
-  override def traitVerify(): R[Operation] =
+  override def traitVerify(): OK[Operation] =
     val params = this.operands.typ ++ this.results.typ
     if params.isEmpty then Right(this)
     else
@@ -197,7 +197,7 @@ trait SameOperandsAndResultTypes extends Operation:
 
 trait SameOperandsAndResultShape extends Operation:
 
-  override def traitVerify(): R[Operation] =
+  override def traitVerify(): OK[Operation] =
     // gets rid of all unranked types already
     val params = (this.operands ++ this.results).map(_.typ).collect {
       case a: ShapedType => a
@@ -215,7 +215,7 @@ trait SameOperandsAndResultShape extends Operation:
 
 trait SameInputOutputTensorDims extends Operation:
 
-  override def traitVerify(): R[Operation] =
+  override def traitVerify(): OK[Operation] =
     // gets rid of all unranked types already
     val params = (this.operands ++ this.results).map(_.typ).collect {
       case a: ShapedType => a
@@ -233,7 +233,7 @@ trait SameInputOutputTensorDims extends Operation:
 
 trait AllTypesMatch(values: Attribute*) extends Operation:
 
-  override def traitVerify(): R[Operation] =
+  override def traitVerify(): OK[Operation] =
     if values.isEmpty then Right(this)
     else
       val first = values.head
@@ -247,7 +247,7 @@ trait AllTypesMatch(values: Attribute*) extends Operation:
 trait BooleanConditionOrMatchingShape(condition: Attribute, result: Attribute)
     extends Operation:
 
-  override def traitVerify(): R[Operation] =
+  override def traitVerify(): OK[Operation] =
     condition match
       case IntegerType(IntData(1), Signless) => Right(this)
       case x: ShapedType                     =>

--- a/dialects/src/main/scala-3/scf/scf.scala
+++ b/dialects/src/main/scala-3/scf/scf.scala
@@ -4,7 +4,7 @@ import scair.clair.codegen.*
 import scair.clair.macros.*
 import scair.dialects.builtin.*
 import scair.ir.*
-import scair.utils.R
+import scair.utils.OK
 
 // ░██████╗ ░█████╗░ ███████╗
 // ██╔════╝ ██╔══██╗ ██╔════╝
@@ -32,7 +32,7 @@ type Index = IndexType
 
 trait AllTypesMatch(values: Attribute*) extends Operation:
 
-  override def traitVerify(): R[Operation] =
+  override def traitVerify(): OK[Operation] =
     if values.isEmpty then Right(this)
     else
       val firstClass = values.head.getClass

--- a/tools/opt/src/main/scala-3/ScairOpt.scala
+++ b/tools/opt/src/main/scala-3/ScairOpt.scala
@@ -4,7 +4,7 @@ import scair.Printer
 import scair.exceptions.VerifyException
 import scair.ir.*
 import scair.tools.ScairToolBase
-import scair.utils.R
+import scair.utils.OK
 import scopt.OParser
 
 import scala.io.BufferedSource
@@ -45,7 +45,7 @@ trait ScairOptBase extends ScairToolBase[ScairOptArgs]:
 
   override def parse(args: ScairOptArgs)(
       input: BufferedSource
-  ): Array[R[Operation]] =
+  ): Array[OK[Operation]] =
     // TODO: more robust separator splitting
     val inputChunks =
       if args.splitInputFile then input.mkString.split("\n// -----\n")
@@ -123,7 +123,7 @@ trait ScairOptBase extends ScairToolBase[ScairOptArgs]:
 
       parsedModule match
         case Right(inputModule) =>
-          val processedModule: R[Operation] =
+          val processedModule: OK[Operation] =
             var module =
               if parsedArgs.skipVerify then Right(inputModule)
               else inputModule.structured.flatMap(_.verify())

--- a/tools/runTool/src/main/scala-3/ScairRun.scala
+++ b/tools/runTool/src/main/scala-3/ScairRun.scala
@@ -5,7 +5,7 @@ import scair.interpreter.Interpreter
 import scair.interpreter.RuntimeCtx
 import scair.ir.*
 import scair.tools.ScairToolBase
-import scair.utils.R
+import scair.utils.OK
 import scopt.OParser
 
 import scala.collection.mutable
@@ -54,7 +54,7 @@ trait ScairRunBase extends ScairToolBase[ScairRunArgs]:
 
   override def parse(args: ScairRunArgs)(
       input: BufferedSource
-  ): Array[R[Operation]] =
+  ): Array[OK[Operation]] =
     // Parse content
     // ONE CHUNK ONLY
 

--- a/tools/src/main/scala-3/Tools.scala
+++ b/tools/src/main/scala-3/Tools.scala
@@ -4,7 +4,7 @@ import scair.MLContext
 import scair.ir.Dialect
 import scair.ir.Operation
 import scair.transformations.ModulePass
-import scair.utils.R
+import scair.utils.OK
 import scopt.OParser
 
 import scala.io.BufferedSource
@@ -44,4 +44,4 @@ abstract class ScairToolBase[Args]:
 
   def parseArgs(args: Array[String]): Args
   def toolName: String
-  def parse(args: Args)(input: BufferedSource): Array[R[Operation]]
+  def parse(args: Args)(input: BufferedSource): Array[OK[Operation]]

--- a/utils/src/main/scala-3/OK.scala
+++ b/utils/src/main/scala-3/OK.scala
@@ -7,4 +7,4 @@ package scair.utils
   *   Implemented in terms of Either right now; only defined for readability for
   *   now.
   */
-type R[+T] = Either[String, T]
+type OK[+T] = Either[String, T]


### PR DESCRIPTION
Define's ScaIR's own error monad as `OK[T]`, because:
- `Option[T]` carries no information on the error.
- `Either[String, T]` is just way to wordy at this point.
- `Try[T]` wants a full-blown `Throwable` as error case, not just a message.

Implemented only in terms of an alias to `Either[String, T]` for now, as-in strictly for readability, which is already nice.
This opens the door to more optimized variants later if we can observe a benefit.