### PR TITLE
Parallelize CI across targets, and cache builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,21 +122,42 @@ jobs:
         pip install --upgrade pip
         pip install lit filecheck
 
-    # # Restore Mill's incremental build cache
-    # - name: Cache Incremental Build
-    #   uses: actions/cache@v4
-    #   with:
-    #     path: ./out
-    #     key: mill-incremental-tests-${{ github.run_id }}-${{ github.run_attempt }}
-    #     restore-keys: |
-    #       mill-incremental-tests-
+    # Restore Mill's incremental build cache
+    - name: Restore incremental cache
+      id: restore-mill-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: out
+        key: mill-incremental-tests-${{ matrix.task }}${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          mill-incremental-tests-${{ matrix.task }}
 
-    - name: Run test target
+    # Try to run the test, with the restored cache if any.
+    # If the cache was restored, failing this falls back to the next step
+    # Otherwise, it just fails the run
+    - name: Run test target (incremental)
+      id: cached-run
+      continue-on-error: ${{ steps.restore-mill-cache.outputs.cache-matched-key != '' }}
       run: |
         export PATH=$PATH:$(pwd)/llvm-project/build/bin/
-        # I can't get it to work with just cleaning the coverage data, for some reason
-        # ./mill clean
         ./mill ${{ matrix.task }}
+
+    # This is ran only if the cache was restored and the initial attempt failed
+    # Just try again from a clean slate
+    - name: Run test target (clean attempt)
+      if: ${{ steps.restore-mill-cache.outputs.cache-matched-key != '' && steps.cached-run.outcome == 'failure' }}
+      run: |
+        export PATH=$PATH:$(pwd)/llvm-project/build/bin/
+        rm out -rf
+        ./mill ${{ matrix.task }}
+
+    # If tests passed, save the cache for the next run
+    - name: Save incremental cache
+      uses: actions/cache/save@v4
+      with:
+        path: out
+        key: mill-incremental-tests-${{ matrix.task }}${{ github.run_id }}-${{ github.run_attempt }}
+
     - name: Upload coverage report to Codecov
       if: matrix.task == 'scoverage'
       uses: codecov/codecov-action@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,11 +80,18 @@ jobs:
   # Tests and coverage
   tests:
 
-    name: "Tests"
+    name: "Tests (${{ matrix.task }})"
 
     runs-on: ubuntu-latest
     needs:
       - ensure-mlir
+    strategy:
+      fail-fast: false
+      matrix:
+        task:
+          - scoverage
+          - filechecks.graal
+          - filechecks.native
 
     steps:
     - name: Checkout Scair
@@ -124,13 +131,14 @@ jobs:
     #     restore-keys: |
     #       mill-incremental-tests-
 
-    - name: Run all tests
+    - name: Run test target
       run: |
         export PATH=$PATH:$(pwd)/llvm-project/build/bin/
         # I can't get it to work with just cleaning the coverage data, for some reason
         # ./mill clean
-        ./mill scoverage + filechecks.graal + filechecks.native
+        ./mill ${{ matrix.task }}
     - name: Upload coverage report to Codecov
+      if: matrix.task == 'scoverage'
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,38 +9,29 @@ on:
 permissions:
   contents: read
 
+env:
+  MLIR-Version: llvmorg-22.1.1
+
 jobs:
 
-  # Tests and coverage
-  tests:
+  # Build or restore MLIR once, then persist it in cache for downstream jobs.
+  ensure-mlir:
 
-    name: "Tests"
+    name: "Ensure MLIR availablity"
 
     runs-on: ubuntu-latest
-    env:
-      MLIR-Version: llvmorg-22.1.1
 
     steps:
-    - name: Checkout Scair
-      uses: actions/checkout@v4
-
-    ##############
-    # MLIR SETUP #
-    ##############
-
-    # Get from cache
-    - name: Cache MLIR build
-      id: cache-binary
-      uses: actions/cache@v4
+    - name: Lookup MLIR cache
+      id: lookup-mlir-cache
+      uses: actions/cache/restore@v4
       with:
         path: llvm-project/build
+        lookup-only: true
         key: mlir-${{ runner.os }}-${{ env.MLIR-Version }}
-        restore-keys: mlir-${{ runner.os }}-${{ env.MLIR-Version }}
-      
-    # Otherwise, get it and build it
-      
+
     - name: Checkout MLIR
-      if: steps.cache-binary.outputs.cache-hit != 'true'
+      if: steps.lookup-mlir-cache.outputs.cache-hit != 'true'
       uses: actions/checkout@v4
       with:
         repository: llvm/llvm-project.git
@@ -48,15 +39,15 @@ jobs:
         ref: ${{ env.MLIR-Version }}
 
     - name: Clang Setup
-      if: steps.cache-binary.outputs.cache-hit != 'true'
+      if: steps.lookup-mlir-cache.outputs.cache-hit != 'true'
       uses: egor-tensin/setup-clang@v1
 
     - name: Ninja Setup
-      if: steps.cache-binary.outputs.cache-hit != 'true'
+      if: steps.lookup-mlir-cache.outputs.cache-hit != 'true'
       uses: lukka/get-cmake@9e431acfe656e5db66cd4930386328fce59cfaba
 
     - name: MLIR configuration
-      if: steps.cache-binary.outputs.cache-hit != 'true'
+      if: steps.lookup-mlir-cache.outputs.cache-hit != 'true'
       run: |
         mkdir llvm-project/build
         cd llvm-project/build
@@ -73,10 +64,42 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release
 
     - name: MLIR build
-      if: steps.cache-binary.outputs.cache-hit != 'true'
+      if: steps.lookup-mlir-cache.outputs.cache-hit != 'true'
       run: |
         cd llvm-project/build
         cmake --build . --target mlir-opt mlir-runner
+
+    - name: Save MLIR build cache
+      if: steps.lookup-mlir-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: llvm-project/build
+        key: mlir-${{ runner.os }}-${{ env.MLIR-Version }}
+
+
+  # Tests and coverage
+  tests:
+
+    name: "Tests"
+
+    runs-on: ubuntu-latest
+    needs:
+      - ensure-mlir
+
+    steps:
+    - name: Checkout Scair
+      uses: actions/checkout@v4
+
+    ##############
+    # MLIR SETUP #
+    ##############
+
+    - name: Restore MLIR build cache
+      uses: actions/cache/restore@v4
+      with:
+        key: mlir-${{ runner.os }}-${{ env.MLIR-Version }}
+        path: llvm-project/build
+        fail-on-cache-miss: true
     
     ###########
     # TESTING #


### PR DESCRIPTION
- JVM, GraalVM Native Image and Scala Native flows are tested in parallel
- Reactivate incremental compilation, with a failsafe. If the incremental cache was used and a test fail, just try it again after wiping the cache (reproducing what was any run recently)