### PR TITLE
ErrorPrinter improvement

### DIFF
--- a/core/src/ir/Attribute.scala
+++ b/core/src/ir/Attribute.scala
@@ -46,7 +46,8 @@ sealed trait Attribute:
    * with the attribute that caused it, without having to explicitly pass 'this' every
    * time.
    */
-  def Err(msg: String) = scair.utils.Err(msg, Some(this))
+  def Err(msg: String, obj: Option[AnyRef] = Some(this)) = scair.utils
+    .Err(msg, obj)
 
 trait TypeAttribute extends Attribute:
   override def prefix: String = "!"

--- a/core/src/ir/Operation.scala
+++ b/core/src/ir/Operation.scala
@@ -49,7 +49,8 @@ trait Operation extends IRNode with IntrusiveNode[Operation]:
    * with the operation that caused it, without having to explicitly pass 'this' every
    * time.
    */
-  def Err(msg: String) = scair.utils.Err(msg, Some(this))
+  def Err(msg: String, obj: Option[AnyRef] = Some(this)) = scair.utils
+    .Err(msg, obj)
 
   final override def deepCopy(using
       blockMapper: mutable.Map[Block, Block] = mutable.Map.empty,

--- a/core/src/print/AssemblyPrinter.scala
+++ b/core/src/print/AssemblyPrinter.scala
@@ -15,8 +15,8 @@ case class AssemblyPrinter(
       .empty,
     val blockNameMap: mutable.Map[Block, String] = mutable.Map.empty,
     protected val p: Writer = new PrintWriter(System.out),
-    private var aliasesMap: Map[Attribute, String] = Map.empty,
-    private var indentLevel: Int = 0,
+    protected var aliasesMap: Map[Attribute, String] = Map.empty,
+    protected var indentLevel: Int = 0,
 ) extends Printer(strictlyGeneric, p):
 
   protected def writer: Writer = p
@@ -93,7 +93,7 @@ case class AssemblyPrinter(
   def print(region: Region): Unit =
     this.scoped._printRegion(region)
 
-  private def _printRegion(region: Region) =
+  protected def _printRegion(region: Region) =
 
     print("{\n")
     region.blocks match

--- a/core/src/print/ErrorPrinter.scala
+++ b/core/src/print/ErrorPrinter.scala
@@ -8,14 +8,15 @@ import java.io.Writer
 import scala.annotation.tailrec
 import scala.collection.mutable
 
-private class ErrorPrinterFilter(writer: Writer) extends PrintWriter(writer):
+private final class ErrorPrinterFilter(writer: Writer)
+    extends PrintWriter(writer):
 
   final val currentColumn = mutable.ListBuffer(0)
 
   var msg: Option[(String, Int, Int)] = None
 
   @tailrec
-  private final def writeRec(str: String, start: Int): Unit =
+  def writeRec(str: String, start: Int): Unit =
     str.indexOf('\n', start) match
       case -1 =>
         currentColumn(currentColumn.length - 1) += str.length - start
@@ -24,16 +25,18 @@ private class ErrorPrinterFilter(writer: Writer) extends PrintWriter(writer):
         currentColumn(currentColumn.length - 1) += i - start
         currentColumn += 0
         super.write(str, start, i - start + 1)
-        msg.map(msg => printMessage(msg._1, msg._2, msg._3))
+        msg.map(printMessage)
         writeRec(str, i + 1)
 
-  def nextMessage(content: String, start: Int, end: Int): Unit =
-    // scala.Console.println(s"Received message, current: $lastLength")
+  def withUnderlinedMessage(toPrint: => Unit, message: String): Unit =
+    val startColumn = lastLength
+    toPrint
+    val end = lastLength
     currentColumn.last match
       case 0 => // new line, just print the message
-        printMessage(content, start, end)
-      case _ =>
-        msg = Some((content, start, end))
+        printMessage(message, startColumn, end)
+      case _ => // Otherwise print it after the current line
+        msg = Some((message, startColumn, end))
 
   final def printMessage(content: String, start: Int, end: Int): Unit =
     msg = None
@@ -56,9 +59,7 @@ private class ErrorPrinterFilter(writer: Writer) extends PrintWriter(writer):
       case l => l
 
   override def write(str: String): Unit =
-    // scala.Console.println(s"Printing: '$str'")
     writeRec(str, 0)
-    // scala.Console.println(s"Finished printing, current: $lastLength")
 
 final class ErrorPrinter(
     error: Err,
@@ -98,32 +99,16 @@ final class ErrorPrinter(
       indentLevel,
     )
 
-  final private def printMessage(content: String, start: Int, end: Int): Unit =
-    1 to start foreach (_ => super.print(" "))
-    start + 1 to end foreach (_ => super.print("^"))
-    super.print("\n")
-    error.msg.linesIterator.foreach(l =>
-      1 to start foreach (_ => super.print(" "))
-      super.print("> ")
-      super.print(l)
-      super.print("\n")
-    )
-    flush()
-
-  final private def withUnderlinedMessage(toPrint: => Unit): Unit =
-    val startColumn = w.lastLength
-    toPrint
-    val endColumn = w.lastLength
-    w.nextMessage(error.msg, startColumn, endColumn)
-
   override def print(operation: Operation): Unit =
-    if obj eq operation then withUnderlinedMessage(super.print(operation))
+    if obj eq operation then
+      w.withUnderlinedMessage(super.print(operation), error.msg)
     else super.print(operation)
 
   override def print(attribute: Attribute): Unit =
-    if obj eq attribute then withUnderlinedMessage(super.print(attribute))
+    if obj eq attribute then
+      w.withUnderlinedMessage(super.print(attribute), error.msg)
     else super.print(attribute)
 
   override def print(value: Value[? <: Attribute]): Unit =
-    if obj eq value then withUnderlinedMessage(super.print(value))
+    if obj eq value then w.withUnderlinedMessage(super.print(value), error.msg)
     else super.print(value)

--- a/core/src/print/ErrorPrinter.scala
+++ b/core/src/print/ErrorPrinter.scala
@@ -12,15 +12,41 @@ private class ErrorPrinterFilter(writer: Writer) extends PrintWriter(writer):
 
   final val currentColumn = mutable.ListBuffer(0)
 
+  var msg: Option[(String, Int, Int)] = None
+
   @tailrec
-  private final def accountLines(str: String, start: Int): Unit =
+  private final def writeRec(str: String, start: Int): Unit =
     str.indexOf('\n', start) match
       case -1 =>
         currentColumn(currentColumn.length - 1) += str.length - start
+        super.write(str)
       case i =>
         currentColumn(currentColumn.length - 1) += i - start
         currentColumn += 0
-        accountLines(str, i + 1)
+        super.write(str, start, i - start)
+        msg.map(printMessage)
+        writeRec(str, i + 1)
+
+  def nextMessage(content: String, start: Int, end: Int): Unit =
+    // scala.Console.println(s"Received message, current: $lastLength")
+    currentColumn.last match
+      case 0 => // new line, just print the message
+        printMessage(content, start, end)
+      case _ =>
+        msg = Some((content, start, end))
+
+  final def printMessage(content: String, start: Int, end: Int): Unit =
+    msg = None
+    1 to start foreach (_ => super.write(" "))
+    start + 1 to end foreach (_ => super.write("^"))
+    super.write("\n")
+    content.linesIterator.foreach(l =>
+      1 to start foreach (_ => super.write(" "))
+      super.write("> ")
+      super.write(l)
+      super.write("\n")
+    )
+    flush()
 
   def lastLength: Int =
     currentColumn.last match
@@ -30,8 +56,9 @@ private class ErrorPrinterFilter(writer: Writer) extends PrintWriter(writer):
       case l => l
 
   override def write(str: String): Unit =
-    accountLines(str, 0)
-    super.write(str)
+    // scala.Console.println(s"Printing: '$str'")
+    writeRec(str, 0)
+    // scala.Console.println(s"Finished printing, current: $lastLength")
 
 final class ErrorPrinter(
     error: Err,
@@ -71,20 +98,23 @@ final class ErrorPrinter(
       indentLevel,
     )
 
-  final private def withUnderlinedMessage(toPrint: => Unit): Unit =
-    val startColumn = p.asInstanceOf[ErrorPrinterFilter].lastLength
-    toPrint
-    val endColumn = p.asInstanceOf[ErrorPrinterFilter].lastLength
-    1 to startColumn foreach (_ => super.print(" "))
-    startColumn + 1 to endColumn foreach (_ => super.print("^"))
+  final private def printMessage(content: String, start: Int, end: Int): Unit =
+    1 to start foreach (_ => super.print(" "))
+    start + 1 to end foreach (_ => super.print("^"))
     super.print("\n")
     error.msg.linesIterator.foreach(l =>
-      1 to startColumn foreach (_ => super.print(" "))
+      1 to start foreach (_ => super.print(" "))
       super.print("> ")
       super.print(l)
       super.print("\n")
     )
     flush()
+
+  final private def withUnderlinedMessage(toPrint: => Unit): Unit =
+    val startColumn = w.lastLength
+    toPrint
+    val endColumn = w.lastLength
+    w.nextMessage(error.msg, startColumn, endColumn)
 
   override def print(operation: Operation): Unit =
     if obj eq operation then withUnderlinedMessage(super.print(operation))

--- a/core/src/print/ErrorPrinter.scala
+++ b/core/src/print/ErrorPrinter.scala
@@ -19,12 +19,12 @@ private class ErrorPrinterFilter(writer: Writer) extends PrintWriter(writer):
     str.indexOf('\n', start) match
       case -1 =>
         currentColumn(currentColumn.length - 1) += str.length - start
-        super.write(str)
+        super.write(str, start, str.length - start)
       case i =>
         currentColumn(currentColumn.length - 1) += i - start
         currentColumn += 0
-        super.write(str, start, i - start)
-        msg.map(printMessage)
+        super.write(str, start, i - start + 1)
+        msg.map(msg => printMessage(msg._1, msg._2, msg._3))
         writeRec(str, i + 1)
 
   def nextMessage(content: String, start: Int, end: Int): Unit =
@@ -63,24 +63,24 @@ private class ErrorPrinterFilter(writer: Writer) extends PrintWriter(writer):
 final class ErrorPrinter(
     error: Err,
     w: ErrorPrinterFilter = ErrorPrinterFilter(new PrintWriter(System.out)),
-    indent: String = "  ",
-    valueNextID: Int = 0,
-    blockNextID: Int = 0,
-    valueNameMap: mutable.Map[Value[? <: Attribute], String] = mutable.Map
+    _indent: String = "  ",
+    _valueNextID: Int = 0,
+    _blockNextID: Int = 0,
+    _valueNameMap: mutable.Map[Value[? <: Attribute], String] = mutable.Map
       .empty,
-    blockNameMap: mutable.Map[Block, String] = mutable.Map.empty,
-    aliasesMap: Map[Attribute, String] = Map.empty,
-    indentLevel: Int = 0,
+    _blockNameMap: mutable.Map[Block, String] = mutable.Map.empty,
+    _aliasesMap: Map[Attribute, String] = Map.empty,
+    _indentLevel: Int = 0,
 ) extends AssemblyPrinter(
       true,
-      indent,
-      valueNextID,
-      blockNextID,
-      valueNameMap,
-      blockNameMap,
+      _indent,
+      _valueNextID,
+      _blockNextID,
+      _valueNameMap,
+      _blockNameMap,
       w,
-      aliasesMap,
-      indentLevel,
+      _aliasesMap,
+      _indentLevel,
     ):
 
   val obj = error.obj.getOrElse(null)

--- a/dialects/src/func/Func.scala
+++ b/dialects/src/func/Func.scala
@@ -139,11 +139,11 @@ case class CallIndirect(
         if callee_operands.map(_.typ) != inTys then
           Err(
             s"func.call_indirect: argument types ${callee_operands.map(_.typ)} do not match callee input types $inTys"
-            // Some(callee)
           )
         else if _results.map(_.typ) != outTys then
           Err(
             s"func.call_indirect: result types ${_results.map(_.typ)} do not match callee output types $outTys",
+            // TODO: Really not ideal error localization, was done for demonstration purposes, feel free to change it.
             Some(callee),
           )
         else OK(this)

--- a/dialects/src/func/Func.scala
+++ b/dialects/src/func/Func.scala
@@ -139,10 +139,12 @@ case class CallIndirect(
         if callee_operands.map(_.typ) != inTys then
           Err(
             s"func.call_indirect: argument types ${callee_operands.map(_.typ)} do not match callee input types $inTys"
+            // Some(callee)
           )
         else if _results.map(_.typ) != outTys then
           Err(
-            s"func.call_indirect: result types ${_results.map(_.typ)} do not match callee output types $outTys"
+            s"func.call_indirect: result types ${_results.map(_.typ)} do not match callee output types $outTys",
+            Some(callee),
           )
         else OK(this)
 

--- a/tests/filecheck/dialects/func/invalid.mlir
+++ b/tests/filecheck/dialects/func/invalid.mlir
@@ -1,0 +1,22 @@
+// RUN: scair-opt %s --verify-diagnostics | filecheck %s
+
+func.func @zero() -> i64 {
+    %zero = "arith.constant"() <{ value = 0 : i64 }> : () -> i64
+    func.return %zero : i64
+}
+
+%zerof = "func.constant"() <{ value = @zero }> : () -> () -> i64
+%zero = "func.call_indirect"(%zerof): (() -> i64) -> i32
+
+// CHECK:       "builtin.module"() ({
+// CHECK-NEXT:    "func.func"() <{sym_name = "zero", function_type = () -> i64}> ({
+// CHECK-NEXT:      %0 = "arith.constant"() <{value = 0}> : () -> i64
+// CHECK-NEXT:      "func.return"(%0) : (i64) -> ()
+// CHECK-NEXT:    }) : () -> ()
+// CHECK-NEXT:    %0 = "func.constant"() <{value = @zero}> : () -> () -> i64
+// CHECK-NEXT:    ^^
+// CHECK-NEXT:    > func.call_indirect: result types List(i32) do not match callee output types List(i64)
+// CHECK-NEXT:    %1 = "func.call_indirect"(%0) : (() -> i64) -> i32
+// CHECK-NEXT:                              ^^
+// CHECK-NEXT:                              > func.call_indirect: result types List(i32) do not match callee output types List(i64)
+// CHECK-NEXT:  }) : () -> ()


### PR DESCRIPTION
Various fixes and a first test of using the ErrorPrinter with an error attached to a value instead of to an operation.

The output format is definitely not great - but it's one, let's improve later.
The fact that it always prints on all occurrences of the value is definitely not great - but let's improve later.
(As having this in this relatively off-putting state would already be of great help to me downstream)