### PR TITLE
IntegerEnumAttr bugfix

### DIFF
--- a/core/src/clair/macros/Macros.scala
+++ b/core/src/clair/macros/Macros.scala
@@ -290,11 +290,11 @@ def generateCheckedPropertyArgument[A <: Attribute: Type](
     value match
       case None          => $ifAbsent
       case Some(prop: A) => prop
-      case Some(_)       =>
+      case Some(value)       =>
         throw new IllegalArgumentException(
           s"Type mismatch for property \"${${ Expr(propName) }}\": " +
             s"expected ${${ Expr(typeName) }}, " +
-            s"but found ${value.getClass.getSimpleName}"
+            s"but found ${value.getClass}"
         )
   }
 

--- a/core/src/clair/macros/Macros.scala
+++ b/core/src/clair/macros/Macros.scala
@@ -290,7 +290,7 @@ def generateCheckedPropertyArgument[A <: Attribute: Type](
     value match
       case None          => $ifAbsent
       case Some(prop: A) => prop
-      case Some(value)       =>
+      case Some(value)   =>
         throw new IllegalArgumentException(
           s"Type mismatch for property \"${${ Expr(propName) }}\": " +
             s"expected ${${ Expr(typeName) }}, " +

--- a/core/src/enums/EnumMacros.scala
+++ b/core/src/enums/EnumMacros.scala
@@ -66,13 +66,14 @@ def enumFromProperty[A <: scala.reflect.Enum: Type](
               Expr(typeName)
             }}"
         )
-      case Some(prop @ IntegerAttr(IntData(i), _)) =>
+      case Some(IntegerAttr(IntData(i), _)) =>
         $enumFromOrdinalFunc(i.toInt)
-      case Some(_) =>
+      case Some(i: A)  => i
+      case Some(value) =>
         throw new IllegalArgumentException(
           s"Type mismatch for property \"${${ Expr(propName) }}\": " +
             s"expected ${${ Expr(typeName) }}, " +
-            s"but found ${value.getClass.getSimpleName}"
+            s"but found ${value.getClass()}"
         )
   }
 

--- a/core/test/src/ir/EnumAttrTest.scala
+++ b/core/test/src/ir/EnumAttrTest.scala
@@ -48,5 +48,5 @@ class EnumAttrTest extends AnyFlatSpec with BeforeAndAfter:
     val op = EnumOperation(Color.Green)
     val destructured = summon[OpDefs[EnumOperation]].destructure(op)
     val restructured = summon[OpDefs[EnumOperation]].structure(destructured)
-    assert(restructured == op)
+    assert(op.color == restructured.color)
   }

--- a/core/test/src/ir/EnumAttrTest.scala
+++ b/core/test/src/ir/EnumAttrTest.scala
@@ -43,3 +43,10 @@ class EnumAttrTest extends AnyFlatSpec with BeforeAndAfter:
       case failure: fastparse.Parsed.Failure =>
         fail(s"Failed to parse operation: $failure.msg")
   }
+
+  it should "destructure and structure correctly" in {
+    val op = EnumOperation(Color.Green)
+    val destructured = summon[OpDefs[EnumOperation]].destructure(op)
+    val restructured = summon[OpDefs[EnumOperation]].structure(destructured)
+    assert(restructured == op)
+  }


### PR DESCRIPTION
Destructuring and restructuring an Operation (which happens indirectly behind the scenes) with an IntegerEnumAttr field was leading to wrong verification errors