### PR TITLE
Maitaining the index of an Operation inside of the Block's operation's list

### DIFF
--- a/core/src/ir/Block.scala
+++ b/core/src/ir/Block.scala
@@ -139,6 +139,7 @@ case class Block private (
 ) extends IRNode:
 
   // it is implicitly true, as BlockOperations data structure will calculate operation order on construction
+  // also the Parser populates the indexes when adding operations into the block - kind of ad-hoc but works :D
   var isOpOrderValid = true
 
   override def recomputeOpOrder(): Unit =

--- a/core/src/ir/Block.scala
+++ b/core/src/ir/Block.scala
@@ -138,10 +138,13 @@ case class Block private (
     val operations: BlockOperations,
 ) extends IRNode:
 
-  final override def parent: Option[Region] = containerRegion
   // it is implicitly true, as BlockOperations data structure will calculate operation order on construction
   var isOpOrderValid = true
-  var containerRegion: Option[Region] = None
+
+  override def recomputeOpOrder(): Unit =
+    if !isOpOrderValid then
+      isOpOrderValid = true
+      operations.computeBlockOrder()
 
   final override def deepCopy(using
       blockMapper: mutable.Map[Block, Block] = mutable.Map.empty,
@@ -155,6 +158,8 @@ case class Block private (
         operations.map(_.deepCopy),
     )
 
+  final override def parent: Option[Region] = containerRegion
+
   operations.foreach(attachOp)
 
   arguments.foreach(a =>
@@ -165,14 +170,7 @@ case class Block private (
     else a.owner = Some(this)
   )
 
-  override def recomputeOpOrder(): Unit =
-    if !isOpOrderValid then
-      isOpOrderValid = true
-      operations.computeBlockOrder()
-
-  /*≡==--==≡≡≡≡≡≡≡≡≡≡≡≡≡==--=≡≡*\
-  ||   BLOCK TRANSFORMATIONS   ||
-  \*≡==---==≡≡≡≡≡≡≡≡≡≡≡==---==≡*/
+  var containerRegion: Option[Region] = None
 
   private def attachOp(op: Operation): Unit =
     op.containerBlock match
@@ -188,21 +186,6 @@ case class Block private (
             )
           case false =>
             op.containerBlock = Some(this)
-
-  def detachOp(op: Operation): Operation =
-    (op.containerBlock `equals` Some(this)) match
-      case true =>
-        op.containerBlock = None
-        operations -= op
-        op
-      case false =>
-        throw new Exception(
-          "MLIROperation can only be detached from a block in which it is contained."
-        )
-
-  def eraseOp(op: Operation, safeErase: Boolean = true) =
-    detachOp(op)
-    op.erase(safeErase)
 
   def addOp(newOp: Operation): Unit =
     val oplen = operations.length
@@ -270,11 +253,20 @@ case class Block private (
           "given as a point of reference does not exist in the current block."
       )
 
-  // def replaceOp
+  def detachOp(op: Operation): Operation =
+    (op.containerBlock `equals` Some(this)) match
+      case true =>
+        op.containerBlock = None
+        operations -= op
+        op
+      case false =>
+        throw new Exception(
+          "MLIROperation can only be detached from a block in which it is contained."
+        )
 
-  /*≡==--==≡≡≡≡≡≡≡≡≡≡≡≡≡==--=≡≡*\
-  ||      BLOCK STRUCTURE      ||
-  \*≡==---==≡≡≡≡≡≡≡≡≡≡≡==---==≡*/
+  def eraseOp(op: Operation, safeErase: Boolean = true) =
+    detachOp(op)
+    op.erase(safeErase)
 
   def structured: OK[Unit] =
     operations.foldLeft[OK[Unit]](OK())((res, op) =>

--- a/core/src/ir/Block.scala
+++ b/core/src/ir/Block.scala
@@ -138,6 +138,11 @@ case class Block private (
     val operations: BlockOperations,
 ) extends IRNode:
 
+  final override def parent: Option[Region] = containerRegion
+  // it is implicitly true, as BlockOperations data structure will calculate operation order on construction
+  var isOpOrderValid = true
+  var containerRegion: Option[Region] = None
+
   final override def deepCopy(using
       blockMapper: mutable.Map[Block, Block] = mutable.Map.empty,
       valueMapper: mutable.Map[Value[Attribute], Value[Attribute]] = mutable.Map
@@ -150,8 +155,6 @@ case class Block private (
         operations.map(_.deepCopy),
     )
 
-  final override def parent: Option[Region] = containerRegion
-
   operations.foreach(attachOp)
 
   arguments.foreach(a =>
@@ -162,7 +165,14 @@ case class Block private (
     else a.owner = Some(this)
   )
 
-  var containerRegion: Option[Region] = None
+  override def recomputeOpOrder(): Unit =
+    if !isOpOrderValid then
+      isOpOrderValid = true
+      operations.computeBlockOrder()
+
+  /*≡==--==≡≡≡≡≡≡≡≡≡≡≡≡≡==--=≡≡*\
+  ||   BLOCK TRANSFORMATIONS   ||
+  \*≡==---==≡≡≡≡≡≡≡≡≡≡≡==---==≡*/
 
   private def attachOp(op: Operation): Unit =
     op.containerBlock match
@@ -178,6 +188,21 @@ case class Block private (
             )
           case false =>
             op.containerBlock = Some(this)
+
+  def detachOp(op: Operation): Operation =
+    (op.containerBlock `equals` Some(this)) match
+      case true =>
+        op.containerBlock = None
+        operations -= op
+        op
+      case false =>
+        throw new Exception(
+          "MLIROperation can only be detached from a block in which it is contained."
+        )
+
+  def eraseOp(op: Operation, safeErase: Boolean = true) =
+    detachOp(op)
+    op.erase(safeErase)
 
   def addOp(newOp: Operation): Unit =
     val oplen = operations.length
@@ -245,20 +270,11 @@ case class Block private (
           "given as a point of reference does not exist in the current block."
       )
 
-  def detachOp(op: Operation): Operation =
-    (op.containerBlock `equals` Some(this)) match
-      case true =>
-        op.containerBlock = None
-        operations -= op
-        op
-      case false =>
-        throw new Exception(
-          "MLIROperation can only be detached from a block in which it is contained."
-        )
+  // def replaceOp
 
-  def eraseOp(op: Operation, safeErase: Boolean = true) =
-    detachOp(op)
-    op.erase(safeErase)
+  /*≡==--==≡≡≡≡≡≡≡≡≡≡≡≡≡==--=≡≡*\
+  ||      BLOCK STRUCTURE      ||
+  \*≡==---==≡≡≡≡≡≡≡≡≡≡≡==---==≡*/
 
   def structured: OK[Unit] =
     operations.foldLeft[OK[Unit]](OK())((res, op) =>

--- a/core/src/ir/BlockOperations.scala
+++ b/core/src/ir/BlockOperations.scala
@@ -30,6 +30,7 @@ object BlockOperations:
   def from(i: IterableOnce[Operation]) =
     val list = new BlockOperations
     list.addAll(i)
+    list.computeBlockOrder()
 
   def unapplySeq(list: BlockOperations): Some[Seq[Operation]] =
     Some(list.toSeq)
@@ -42,6 +43,15 @@ class BlockOperations extends IntrusiveList[Operation]:
   private inline def handleOperationRemoval(op: Operation) =
     op.operands
       .foreachWithIndex((o, i) => o.uses.filterInPlace(_.operation != op))
+
+  final def computeBlockOrder(): this.type =
+    var idx = 0
+    this.foreach { op =>
+      op.blockIndex = idx
+      idx += 1
+      op.recomputeOpOrder()
+    }
+    this
 
   override final def addOne(elem: Operation): this.type =
     handleOperationInsertion(elem)

--- a/core/src/ir/Operation.scala
+++ b/core/src/ir/Operation.scala
@@ -39,9 +39,12 @@ trait IRNode:
         .empty,
   ): IRNode
 
+  def recomputeOpOrder(): Unit = ???
+
 trait Operation extends IRNode with IntrusiveNode[Operation]:
 
   final override def parent = containerBlock
+  var blockIndex = -1
 
   /*
    * Return an error message wrapping this operation. Purposefully shadowing the Err
@@ -77,6 +80,9 @@ trait Operation extends IRNode with IntrusiveNode[Operation]:
     // else
     r.owner = Some(this)
   )
+
+  override def recomputeOpOrder(): Unit =
+    regions.foreach(_.recomputeOpOrder())
 
   def name: String
 

--- a/core/src/ir/Region.scala
+++ b/core/src/ir/Region.scala
@@ -46,6 +46,9 @@ case class Region(
 
   blocks.foreach(attachBlock)
 
+  override def recomputeOpOrder(): Unit =
+    blocks.foreach(_.recomputeOpOrder())
+
   def structured =
     blocks.foldLeft[OK[Unit]](OK())((res, block) =>
       res.flatMap(_ => block.structured)

--- a/core/src/parse/Parser.scala
+++ b/core/src/parse/Parser.scala
@@ -625,9 +625,13 @@ private def populateBlockArgsP[$: P](
   )
 
 private def blockBodyP[$: P](block: Block)(using Parser) =
+  // TODO: temporary solution to populate indexes within block body.
+  var idx = 0
   operationP.map(op =>
     op.containerBlock = Some(block)
     block.operations.addOne(op): Unit
+    op.blockIndex = idx
+    idx += 1
   ).rep ~ Pass(block)
 
 def blockP[$: P](using Parser) = P(

--- a/core/src/transformations/PatternRewriter.scala
+++ b/core/src/transformations/PatternRewriter.scala
@@ -212,6 +212,11 @@ class PatternRewriteWalker(
 
     override def operationRemovalHandler: Operation => Unit =
       (op: Operation) =>
+        // here the logic is simple - we invalidate the op order every time an operation is removed from the block
+        op.containerBlock match
+          case Some(block) => 
+            block.isOpOrderValid = false
+          case None        => ()
         clearWorklist(op)
         op.operands.foreach((o) =>
           o.owner match
@@ -220,7 +225,12 @@ class PatternRewriteWalker(
         )
 
     override def operationInsertionHandler: Operation => Unit =
-      populateWorklist
+      (op: Operation) =>
+        // similarly, we invalidate the op order every time an operation is added from the block
+        op.containerBlock match
+          case Some(block) => block.isOpOrderValid = false
+          case None        => ()
+        populateWorklist(op)
 
     def eraseOp(op: Operation): Unit =
       super.eraseOp(op)

--- a/core/src/transformations/PatternRewriter.scala
+++ b/core/src/transformations/PatternRewriter.scala
@@ -214,9 +214,9 @@ class PatternRewriteWalker(
       (op: Operation) =>
         // here the logic is simple - we invalidate the op order every time an operation is removed from the block
         op.containerBlock match
-          case Some(block) => 
+          case Some(block) =>
             block.isOpOrderValid = false
-          case None        => ()
+          case None => ()
         clearWorklist(op)
         op.operands.foreach((o) =>
           o.owner match

--- a/core/test/src/ir/Block.scala
+++ b/core/test/src/ir/Block.scala
@@ -105,6 +105,36 @@ class BlockTest extends AnyFlatSpec with BeforeAndAfter:
     }
   }
 
+  "Block Creation" should "correctly index nested operations on creation" in {
+    val ctx = MLContext()
+    val parser = Parser(ctx, allowUnregisteredDialect = true)
+    val input = parser.parse("""
+%0 = "test.op1"() ({
+  %0 = "test.op1"() : () -> i32
+  %1 = "test.op2"(%0) : (i32) -> i32
+  "test.op3"(%1) ({
+    %3 = "test.op1"() : () -> i32
+    %4 = "test.op2"(%3) : (i32) -> i32
+    "test.op3"(%1) : (i32) -> ()
+  }) : (i32) -> ()
+}) : () -> i32
+%1 = "test.op2"(%0) : (i32) -> i32
+"test.op3"(%1) : (i32) -> ()
+""").get.value
+
+    input.regions(0).blocks(0).operations(0).regions(0).blocks(0).operations.zipWithIndex.foreach {
+      case (op, idx) =>
+        op.blockIndex shouldEqual idx
+    }
+
+    input.regions(0).blocks(0).operations(0) // test.op1
+      .regions(0).blocks(0).operations(2)    // nested test.op3
+      .regions(0).blocks(0).operations.zipWithIndex.foreach {
+      case (op, idx) =>
+        op.blockIndex shouldEqual idx
+    }
+  }
+
   "Block Transformations via Passes" should
     "break the indexing of operations" in {
       val ctx = MLContext()
@@ -136,3 +166,45 @@ class BlockTest extends AnyFlatSpec with BeforeAndAfter:
 
       output.regions(0).blocks(0).isOpOrderValid shouldEqual false
     }
+  
+  "Block Transformations via Passes" should "preserve the indexing of untouched blocks" in {
+    val ctx = MLContext()
+    val parser = Parser(ctx, allowUnregisteredDialect = true)
+    val input = parser.parse("""
+%0 = "test.op1"() ({
+  %0 = "test.op1"() : () -> i32
+  %1 = "test.op2"(%0) : (i32) -> i32
+  "test.op3"(%1) ({
+    %0 = "test.op1"() : () -> i64
+    %1 = "test.op2"(%0) : (i64) -> i64
+    "test.op3"(%1) : (i64) -> ()
+  }) : (i32) -> ()
+}) : () -> i32
+%1 = "test.op2"(%0) : (i32) -> i32
+"test.op3"(%1) : (i32) -> ()
+""").get.value
+
+    object TestPattern extends RewritePattern:
+        override def matchAndRewrite(
+            op: Operation,
+            rewriter: PatternRewriter,
+        ): Unit =
+          val newRes = op.results.map(_ match
+            case Result(I32) => Result(I64)
+            case r           => r)
+          if newRes != op.results then
+            rewriter.replaceOp(op, op.updated(results = newRes))
+
+    final class TestPass(ctx: MLContext) extends WalkerPass(ctx):
+      override val name = "test-test"
+      override final val walker = PatternRewriteWalker(TestPattern)
+
+    val pass = TestPass(ctx)
+
+    val output = pass.transform(input)
+
+    output.regions(0).blocks(0).isOpOrderValid shouldEqual false
+    input.regions(0).blocks(0).operations(0) // test.op1
+      .regions(0).blocks(0).operations(2)    // nested test.op3
+      .regions(0).blocks(0).isOpOrderValid shouldEqual true
+  }

--- a/core/test/src/ir/Block.scala
+++ b/core/test/src/ir/Block.scala
@@ -6,9 +6,12 @@ import org.scalatest.matchers.should.Matchers.*
 import org.scalatest.prop.TableDrivenPropertyChecks.forAll
 import org.scalatest.prop.Tables.Table
 import scair.print.AssemblyPrinter
-import scair.dialects.builtin.{I32, IntegerType, IndexType}
-import java.io.StringWriter
-import java.io.PrintWriter
+import scair.dialects.builtin.*
+import scair.ir.*
+import scair.transformations.*
+import scair.parse.Parser
+import scair.MLContext
+import java.io.*
 
 import scair.dialects.test.TestOp
 
@@ -85,4 +88,49 @@ class BlockTest extends AnyFlatSpec with BeforeAndAfter:
     printer.print(block)
     out.toString() shouldEqual ir
 
+  }
+
+  "Block Creation" should "correctly index operations on creation" in {
+    val ctx = MLContext()
+    val parser = Parser(ctx, allowUnregisteredDialect = true)
+    val input = parser.parse("""
+%0 = "test.op1"() : () -> i32
+%1 = "test.op2"(%0) : (i32) -> i32
+"test.op3"(%1) : (i32) -> ()
+""").get.value
+    
+    input.regions(0).blocks(0).operations.zipWithIndex.foreach { case (op, idx) =>
+      op.blockIndex shouldEqual idx
+    }
+  }
+
+  "Block Transformations via Passes" should "break the indexing of operations" in {
+    val ctx = MLContext()
+    val parser = Parser(ctx, allowUnregisteredDialect = true)
+    val input = parser.parse("""
+%0 = "test.op1"() : () -> i32
+%1 = "test.op2"(%0) : (i32) -> i32
+"test.op3"(%1) : (i32) -> ()
+""").get.value
+
+    object TestPattern extends RewritePattern:
+      override def matchAndRewrite(
+          op: Operation,
+          rewriter: PatternRewriter,
+      ): Unit =
+        val newRes = op.results.map(_ match
+          case Result(I32) => Result(I64)
+          case r           => r)
+        if newRes != op.results then
+          rewriter.replaceOp(op, op.updated(results = newRes))
+
+    final class TestPass(ctx: MLContext) extends WalkerPass(ctx):
+      override val name = "test-test"
+      override final val walker = PatternRewriteWalker(TestPattern)
+
+    val pass = TestPass(ctx)
+
+    val output = pass.transform(input) 
+
+    output.regions(0).blocks(0).isOpOrderValid shouldEqual false
   }

--- a/core/test/src/ir/Block.scala
+++ b/core/test/src/ir/Block.scala
@@ -122,17 +122,16 @@ class BlockTest extends AnyFlatSpec with BeforeAndAfter:
 "test.op3"(%1) : (i32) -> ()
 """).get.value
 
-    input.regions(0).blocks(0).operations(0).regions(0).blocks(0).operations.zipWithIndex.foreach {
-      case (op, idx) =>
+    input.regions(0).blocks(0).operations(0).regions(0).blocks(0).operations
+      .zipWithIndex.foreach { case (op, idx) =>
         op.blockIndex shouldEqual idx
-    }
+      }
 
     input.regions(0).blocks(0).operations(0) // test.op1
-      .regions(0).blocks(0).operations(2)    // nested test.op3
-      .regions(0).blocks(0).operations.zipWithIndex.foreach {
-      case (op, idx) =>
+      .regions(0).blocks(0).operations(2) // nested test.op3
+      .regions(0).blocks(0).operations.zipWithIndex.foreach { case (op, idx) =>
         op.blockIndex shouldEqual idx
-    }
+      }
   }
 
   "Block Transformations via Passes" should
@@ -166,11 +165,12 @@ class BlockTest extends AnyFlatSpec with BeforeAndAfter:
 
       output.regions(0).blocks(0).isOpOrderValid shouldEqual false
     }
-  
-  "Block Transformations via Passes" should "preserve the indexing of untouched blocks" in {
-    val ctx = MLContext()
-    val parser = Parser(ctx, allowUnregisteredDialect = true)
-    val input = parser.parse("""
+
+  "Block Transformations via Passes" should
+    "preserve the indexing of untouched blocks" in {
+      val ctx = MLContext()
+      val parser = Parser(ctx, allowUnregisteredDialect = true)
+      val input = parser.parse("""
 %0 = "test.op1"() ({
   %0 = "test.op1"() : () -> i32
   %1 = "test.op2"(%0) : (i32) -> i32
@@ -184,7 +184,7 @@ class BlockTest extends AnyFlatSpec with BeforeAndAfter:
 "test.op3"(%1) : (i32) -> ()
 """).get.value
 
-    object TestPattern extends RewritePattern:
+      object TestPattern extends RewritePattern:
         override def matchAndRewrite(
             op: Operation,
             rewriter: PatternRewriter,
@@ -195,16 +195,16 @@ class BlockTest extends AnyFlatSpec with BeforeAndAfter:
           if newRes != op.results then
             rewriter.replaceOp(op, op.updated(results = newRes))
 
-    final class TestPass(ctx: MLContext) extends WalkerPass(ctx):
-      override val name = "test-test"
-      override final val walker = PatternRewriteWalker(TestPattern)
+      final class TestPass(ctx: MLContext) extends WalkerPass(ctx):
+        override val name = "test-test"
+        override final val walker = PatternRewriteWalker(TestPattern)
 
-    val pass = TestPass(ctx)
+      val pass = TestPass(ctx)
 
-    val output = pass.transform(input)
+      val output = pass.transform(input)
 
-    output.regions(0).blocks(0).isOpOrderValid shouldEqual false
-    input.regions(0).blocks(0).operations(0) // test.op1
-      .regions(0).blocks(0).operations(2)    // nested test.op3
-      .regions(0).blocks(0).isOpOrderValid shouldEqual true
-  }
+      output.regions(0).blocks(0).isOpOrderValid shouldEqual false
+      input.regions(0).blocks(0).operations(0) // test.op1
+        .regions(0).blocks(0).operations(2) // nested test.op3
+        .regions(0).blocks(0).isOpOrderValid shouldEqual true
+    }

--- a/core/test/src/ir/Block.scala
+++ b/core/test/src/ir/Block.scala
@@ -98,39 +98,41 @@ class BlockTest extends AnyFlatSpec with BeforeAndAfter:
 %1 = "test.op2"(%0) : (i32) -> i32
 "test.op3"(%1) : (i32) -> ()
 """).get.value
-    
-    input.regions(0).blocks(0).operations.zipWithIndex.foreach { case (op, idx) =>
-      op.blockIndex shouldEqual idx
+
+    input.regions(0).blocks(0).operations.zipWithIndex.foreach {
+      case (op, idx) =>
+        op.blockIndex shouldEqual idx
     }
   }
 
-  "Block Transformations via Passes" should "break the indexing of operations" in {
-    val ctx = MLContext()
-    val parser = Parser(ctx, allowUnregisteredDialect = true)
-    val input = parser.parse("""
+  "Block Transformations via Passes" should
+    "break the indexing of operations" in {
+      val ctx = MLContext()
+      val parser = Parser(ctx, allowUnregisteredDialect = true)
+      val input = parser.parse("""
 %0 = "test.op1"() : () -> i32
 %1 = "test.op2"(%0) : (i32) -> i32
 "test.op3"(%1) : (i32) -> ()
 """).get.value
 
-    object TestPattern extends RewritePattern:
-      override def matchAndRewrite(
-          op: Operation,
-          rewriter: PatternRewriter,
-      ): Unit =
-        val newRes = op.results.map(_ match
-          case Result(I32) => Result(I64)
-          case r           => r)
-        if newRes != op.results then
-          rewriter.replaceOp(op, op.updated(results = newRes))
+      object TestPattern extends RewritePattern:
+        override def matchAndRewrite(
+            op: Operation,
+            rewriter: PatternRewriter,
+        ): Unit =
+          val newRes = op.results.map(_ match
+            case Result(I32) => Result(I64)
+            case r           => r)
+          if newRes != op.results then
+            rewriter.replaceOp(op, op.updated(results = newRes))
 
-    final class TestPass(ctx: MLContext) extends WalkerPass(ctx):
-      override val name = "test-test"
-      override final val walker = PatternRewriteWalker(TestPattern)
+      final class TestPass(ctx: MLContext) extends WalkerPass(ctx):
+        override val name = "test-test"
+        override final val walker = PatternRewriteWalker(TestPattern)
 
-    val pass = TestPass(ctx)
+      val pass = TestPass(ctx)
 
-    val output = pass.transform(input) 
+      val output = pass.transform(input)
 
-    output.regions(0).blocks(0).isOpOrderValid shouldEqual false
-  }
+      output.regions(0).blocks(0).isOpOrderValid shouldEqual false
+    }

--- a/tools/opt/src/ScairOpt.scala
+++ b/tools/opt/src/ScairOpt.scala
@@ -157,7 +157,6 @@ trait ScairOptBase extends ScairToolBase[ScairOptArgs]:
                       sys.exit(1)
                   module.map { op =>
                     val out = pass.transform(op)
-                    out.recomputeOpOrder()
 
                     if !parsedArgs.skipVerify then
                       Verifier.verify(out).fold(

--- a/tools/opt/src/ScairOpt.scala
+++ b/tools/opt/src/ScairOpt.scala
@@ -157,6 +157,7 @@ trait ScairOptBase extends ScairToolBase[ScairOptArgs]:
                       sys.exit(1)
                   module.map { op =>
                     val out = pass.transform(op)
+                    out.recomputeOpOrder()
 
                     if !parsedArgs.skipVerify then
                       Verifier.verify(out).fold(


### PR DESCRIPTION
This is a set up PR that will help us better track exactly where an Operation is within a Block - which becomes very helpful for Analysis such as SSA Dominance.

Now each Operation directly holds the index of its position within the BlockOperations data structure. 

BlockOperations data structure now holds a method that calculates and updates the position of every Operation contained within.

IRNode also now contains a new method to calculate the Operation's index recursively within the IR. 