### PR TITLE
Early version of ScaIR's landing webpage

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,12 @@ jobs:
 
     - name: Generate documentation
       run: ./mill unidocSite
-      
+
+    - name: Install landing page as site homepage
+      run: |
+        rm out/unidocSite.dest/index.html
+        cp website/index.html out/unidocSite.dest/index.html
+
     - name: Upload static files as artifact
       id: deployment
       uses: actions/upload-pages-artifact@v3 # or specific "vX.X.X" version tag for this action

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html data-pathToRoot="" data-rawLocation="index" data-dynamicSideMenu="false">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <title>ScaIR</title>
+  <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
+  <script type="text/javascript" src="scripts/theme.js"></script>
+  <link rel="stylesheet" href="styles/theme/bundle.css">
+  <style>
+    body {
+      margin: 0;
+      background-color: var(--mauve1);
+      color: var(--mauve12);
+      font-family: "Inter-Regular", sans-serif;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+    }
+    .landing {
+      text-align: center;
+      max-width: 640px;
+      padding: 2rem;
+    }
+    .landing h1 {
+      font-family: "Inter-Bold", sans-serif;
+      font-size: 40px;
+      margin-bottom: 0.5rem;
+    }
+    .landing p {
+      font-family: "Inter-Regular", sans-serif;
+      font-size: 18px;
+      color: var(--mauve11);
+      margin-bottom: 2.5rem;
+    }
+    .buttons {
+      display: flex;
+      gap: 1rem;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+    .buttons a {
+      display: inline-block;
+      padding: 0.85rem 2rem;
+      border-radius: 8px;
+      background-color: var(--mauve12);
+      color: var(--mauve1);
+      text-decoration: none;
+      font-family: "Inter-SemiBold", sans-serif;
+      font-size: 16px;
+    }
+    .buttons a:hover {
+      opacity: 0.85;
+    }
+  </style>
+</head>
+<body>
+  <div class="landing">
+    <h1>ScaIR</h1>
+    <p>MLIR inspired Scala Compiler Framework</p>
+    <div class="buttons">
+      <a href="scair.html">API Reference</a>
+      <a href="docs/index.html">Documentation</a>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
This is currently what it looks like:
<img width="1494" height="844" alt="Screenshot from 2026-07-06 13-38-21" src="https://github.com/user-attachments/assets/d7dc5ee8-3029-4a9c-9c1c-d7e370fb8aa7" />

Reasoning:
- I think it would be nice to create some sort of proper webpage for ScaIR. Currently the webpage jumps straight into tutorials and API, while it would be nice to have some high-level landing page.
- That being said. I don't think the above image is the final version for this :D Just an early prototype to also discuss what exactly we might want in that landing page. 

Problems:
- A very hacky first solution to motivate some discussions about how we should approach this. Right now it is literally just a custom index.html page, which references and itself is copied into the right places of the auto-generated unidocSite from mill. It feels quite hacky, I'm not sure if there is a better way to do this via mill APIs directly - probably :D.