### PR TITLE
Keep MLIR cache entry warm

### DIFF
--- a/.github/actions/ensure-mlir/action.yml
+++ b/.github/actions/ensure-mlir/action.yml
@@ -1,0 +1,81 @@
+name: Ensure MLIR
+description: >
+  Make sure the pinned MLIR version is available in the build cache, building
+  and caching it if it is not. Single source of truth for the MLIR version and
+  the cache key it is stored under.
+
+outputs:
+  cache-key:
+    description: "Cache key the llvm-project/build directory is stored under"
+    value: ${{ steps.version.outputs.cache-key }}
+  cache-hit:
+    description: "'true' if the build was already cached, i.e. nothing was built"
+    value: ${{ steps.lookup-mlir-cache.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+  - name: MLIR version
+    id: version
+    shell: bash
+    env:
+      MLIR_VERSION: llvmorg-22.1.1
+    run: |
+      echo "version=$MLIR_VERSION" >> "$GITHUB_OUTPUT"
+      echo "cache-key=mlir-${{ runner.os }}-$MLIR_VERSION" >> "$GITHUB_OUTPUT"
+
+  - name: Lookup MLIR cache
+    id: lookup-mlir-cache
+    uses: actions/cache/restore@v4
+    with:
+      path: llvm-project/build
+      lookup-only: true
+      key: ${{ steps.version.outputs.cache-key }}
+
+  - name: Checkout MLIR
+    if: steps.lookup-mlir-cache.outputs.cache-hit != 'true'
+    uses: actions/checkout@v4
+    with:
+      repository: llvm/llvm-project.git
+      path: llvm-project
+      ref: ${{ steps.version.outputs.version }}
+
+  - name: Clang Setup
+    if: steps.lookup-mlir-cache.outputs.cache-hit != 'true'
+    uses: egor-tensin/setup-clang@v1
+
+  - name: Ninja Setup
+    if: steps.lookup-mlir-cache.outputs.cache-hit != 'true'
+    uses: lukka/get-cmake@9e431acfe656e5db66cd4930386328fce59cfaba
+
+  - name: MLIR configuration
+    if: steps.lookup-mlir-cache.outputs.cache-hit != 'true'
+    shell: bash
+    run: |
+      mkdir llvm-project/build
+      cd llvm-project/build
+      cmake -G Ninja ../llvm \
+        -DLLVM_ENABLE_PROJECTS=mlir \
+        -DLLVM_TARGETS_TO_BUILD="Native" \
+        -DLLVM_ENABLE_LLD=ON \
+        -DLLVM_INCLUDE_BENCHMARKS=OFF \
+        -DLLVM_INCLUDE_EXAMPLES=OFF \
+        -DCMAKE_C_COMPILER=clang \
+        -DCMAKE_CXX_COMPILER=clang++ \
+        -DCMAKE_C_FLAGS="-pipe" \
+        -DCMAKE_CXX_FLAGS="-pipe" \
+        -DCMAKE_BUILD_TYPE=Release
+
+  - name: MLIR build
+    if: steps.lookup-mlir-cache.outputs.cache-hit != 'true'
+    shell: bash
+    run: |
+      cd llvm-project/build
+      cmake --build . --target mlir-opt mlir-runner
+
+  - name: Save MLIR build cache
+    if: steps.lookup-mlir-cache.outputs.cache-hit != 'true'
+    uses: actions/cache/save@v4
+    with:
+      path: llvm-project/build
+      key: ${{ steps.version.outputs.cache-key }}

--- a/.github/workflows/keep-mlir-cache-warm.yml
+++ b/.github/workflows/keep-mlir-cache-warm.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Checkout Scair
+      uses: actions/checkout@v4
     - name: Ensure MLIR availability
       id: mlir
       uses: ./.github/actions/ensure-mlir

--- a/.github/workflows/keep-mlir-cache-warm.yml
+++ b/.github/workflows/keep-mlir-cache-warm.yml
@@ -1,0 +1,32 @@
+name: Keep MLIR cache warm
+
+# GitHub evicts cache entries that have not been accessed for 7 days, and
+# rebuilding MLIR from scratch costs hours of CI. Touch the entry twice a week,
+# or rebuild it off-peak rather than on someone's pull request if it did expire.
+on:
+  schedule:
+    - cron: '0 4 * * 1,4'
+  workflow_dispatch:
+
+jobs:
+
+  warm-mlir-cache:
+
+    name: "Touch the MLIR build cache"
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Ensure MLIR availability
+      id: mlir
+      uses: ./.github/actions/ensure-mlir
+
+    # A lookup alone does not count as using the cache; only an actual restore
+    # resets GitHub's eviction timer. A cache miss just rebuilt and saved the
+    # entry, which is fresh by definition, so only touch on a hit.
+    - name: Touch MLIR cache
+      if: steps.mlir.outputs.cache-hit == 'true'
+      uses: actions/cache/restore@v4
+      with:
+        path: llvm-project/build
+        key: ${{ steps.mlir.outputs.cache-key }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,6 @@ on:
 permissions:
   contents: read
 
-env:
-  MLIR-Version: llvmorg-22.1.1
-
 jobs:
 
   # Build or restore MLIR once, then persist it in cache for downstream jobs.
@@ -21,60 +18,13 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    outputs:
+      mlir-cache-key: ${{ steps.ensure-mlir.outputs.cache-key }}
+
     steps:
-    - name: Lookup MLIR cache
-      id: lookup-mlir-cache
-      uses: actions/cache/restore@v4
-      with:
-        path: llvm-project/build
-        lookup-only: true
-        key: mlir-${{ runner.os }}-${{ env.MLIR-Version }}
-
-    - name: Checkout MLIR
-      if: steps.lookup-mlir-cache.outputs.cache-hit != 'true'
-      uses: actions/checkout@v4
-      with:
-        repository: llvm/llvm-project.git
-        path: llvm-project
-        ref: ${{ env.MLIR-Version }}
-
-    - name: Clang Setup
-      if: steps.lookup-mlir-cache.outputs.cache-hit != 'true'
-      uses: egor-tensin/setup-clang@v1
-
-    - name: Ninja Setup
-      if: steps.lookup-mlir-cache.outputs.cache-hit != 'true'
-      uses: lukka/get-cmake@9e431acfe656e5db66cd4930386328fce59cfaba
-
-    - name: MLIR configuration
-      if: steps.lookup-mlir-cache.outputs.cache-hit != 'true'
-      run: |
-        mkdir llvm-project/build
-        cd llvm-project/build
-        cmake -G Ninja ../llvm \
-          -DLLVM_ENABLE_PROJECTS=mlir \
-          -DLLVM_TARGETS_TO_BUILD="Native" \
-          -DLLVM_ENABLE_LLD=ON \
-          -DLLVM_INCLUDE_BENCHMARKS=OFF \
-          -DLLVM_INCLUDE_EXAMPLES=OFF \
-          -DCMAKE_C_COMPILER=clang \
-          -DCMAKE_CXX_COMPILER=clang++ \
-          -DCMAKE_C_FLAGS="-pipe" \
-          -DCMAKE_CXX_FLAGS="-pipe" \
-          -DCMAKE_BUILD_TYPE=Release
-
-    - name: MLIR build
-      if: steps.lookup-mlir-cache.outputs.cache-hit != 'true'
-      run: |
-        cd llvm-project/build
-        cmake --build . --target mlir-opt mlir-runner
-
-    - name: Save MLIR build cache
-      if: steps.lookup-mlir-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
-      with:
-        path: llvm-project/build
-        key: mlir-${{ runner.os }}-${{ env.MLIR-Version }}
+    - name: Ensure MLIR availability
+      id: ensure-mlir
+      uses: ./.github/actions/ensure-mlir
 
 
   # Tests and coverage
@@ -104,7 +54,7 @@ jobs:
     - name: Restore MLIR build cache
       uses: actions/cache/restore@v4
       with:
-        key: mlir-${{ runner.os }}-${{ env.MLIR-Version }}
+        key: ${{ needs.ensure-mlir.outputs.mlir-cache-key }}
         path: llvm-project/build
         fail-on-cache-miss: true
     
@@ -113,9 +63,9 @@ jobs:
     ###########
 
     - name: Python Setup
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
-        python-version: '3.12'
+        python-version: '3.14'
 
     - name: Install lit and filecheck (python version)
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,8 @@ jobs:
       mlir-cache-key: ${{ steps.ensure-mlir.outputs.cache-key }}
 
     steps:
+    - name: Checkout Scair
+      uses: actions/checkout@v4
     - name: Ensure MLIR availability
       id: ensure-mlir
       uses: ./.github/actions/ensure-mlir


### PR DESCRIPTION
Pull the MLIR build part in its own action, to be used as usual and twice a week automatically, to keep it in cache, until we have time for and/or need a better move :slightly_smiling_face: 