### PR TITLE
Multi-block interpretation and interpreter/README.md

### DIFF
--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -1,0 +1,217 @@
+# ScaIR MLIR Interpreter
+
+[![build](https://github.com/edin-dal/scair/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/edin-dal/scair/actions/workflows/tests.yml)
+[![codecov](https://codecov.io/github/edin-dal/scair/graph/badge.svg?token=H3TBWG1YNT)](https://codecov.io/github/edin-dal/scair)
+[![license](https://img.shields.io/badge/license-Apache_2.0-blue)](https://github.com/edin-dal/scair/blob/main/LICENSE)
+
+ScaIR's extensible interpreter infrastructure for MLIR. Enables the high-level interpretation and execution of MLIR programs through its bookkeeping and execution engine, all without lowering. To fully accomodate the open-endedness of MLIR dialects, the tool allows for the extension of per-dialect and per-operation implementation logic.
+
+## Overview
+
+The `interpreter` module adds an execution path to ScaIR. It is used by the `scair-run` command-line tool (defined in `tools/runTool`), which:
+
+1. parses an `.mlir` file or stdin,
+2. registers the available supported dialects
+3. invokes the interpreter on the `.mlir` file
+4. returns the result once execution is completed
+
+## Features
+
+- Direct MLIR-level execution of MLIR programs
+- Scoped SSA value tracking with parent-scope lookup
+- Structured and multi-block CFG control flow handling
+- Function calls, recursion, and a built-in `@print`
+- Extensible operation implementations via the `OpImpl` trait
+- Terminator dispatch via the `OpTerminatorImpl` trait
+- Extensible dialect implementations via the `InterpreterDialects` class
+- Supports the `arith`, `memref`, `scf` dialects among others
+
+## Getting started
+
+### Prerequisites
+
+- A checkout of this repository
+- Mill — use the `./mill` wrapper from the repository root
+
+### Run a program
+
+Create `add.mlir`:
+
+```mlir
+builtin.module {
+  func.func @main() -> i64 {
+    %0 = "arith.constant"() <{value = 30 : i64}> : () -> i64
+    %1 = "arith.constant"() <{value = 28 : i64}> : () -> i64
+    %2 = "arith.addi"(%0, %1) <{overflowFlags = #arith.overflow<none>}> : (i64, i64) -> i64
+    func.return %2 : i64
+  }
+}
+```
+
+Run it from the repository root:
+
+```bash
+./mill tools.runTool.run add.mlir
+```
+
+Output:
+
+```text
+Result: 58
+```
+
+> [!IMPORTANT]
+> Execution always starts at `func.func @main`. If no `main` symbol exists, the interpreter fails with `Function main not found`.
+
+When no file argument is given, `scair-run` reads IR from stdin.
+
+## Examples
+
+### Loops and loop-carried values
+
+```mlir
+builtin.module {
+  func.func @main() -> (i32) {
+    %n    = "arith.constant"() <{value = 10 : i32}> : () -> i32
+    %lb   = "arith.constant"() <{value = 0 : i32}> : () -> i32
+    %step = "arith.constant"() <{value = 1 : i32}> : () -> i32
+
+    %a0   = "arith.constant"() <{value = 0 : i32}> : () -> i32
+    %b0   = "arith.constant"() <{value = 1 : i32}> : () -> i32
+
+    %a_res, %b_res = "scf.for"(%lb, %n, %step, %a0, %b0) ({
+    ^bb0(%iv: i32, %a: i32, %b: i32):
+      %next = "arith.addi"(%a, %b) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
+      "scf.yield"(%b, %next) : (i32, i32) -> ()
+    }) : (i32, i32, i32, i32, i32) -> (i32, i32)
+
+    %fib_n = "arith.addi"(%a_res, %lb) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
+
+    func.return %fib_n : i32
+  }
+}
+```
+
+```text
+Result: 55
+```
+
+See examples of more complete programs in `tests/filecheck/interpreter/`.
+
+## Supported operations
+
+| Dialect | Operations | Notes |
+| --- | --- | --- |
+| `arith` | `constant`, `addi`, `subi`, `muli`, `divsi`, `divui`, `andi`, `ori`, `xori`, `shli`, `shrsi`, `shrui`, `cmpi`, `select` | integer operands only |
+| `func` | `func`, `call`, `return`, built-in `@print` | `@print` writes a single operand to stdout |
+| `memref` | `alloc`, `load`, `store` | backed by `ShapedArray` |
+| `scf` | `for`, `if`, `yield` | loop-carried values supported |
+| LLVM terminators | `llvm.br`, `llvm.cond_br`, `llvm.return`, `llvm.unreachable` | drive multi-block control flow; `llvm.return` returns from the function |
+
+## How it works
+
+| Component | Responsibility |
+| --- | --- |
+| `Interpreter` | Walks the module, dispatches operations, maintains the symbol table |
+| `OpImpl` | Per-operation implementation: `compute` returns results, which are stored in the current context |
+| `OpTerminatorImpl` | Terminator implementation: returns a `CFGStep` (jump to a block or return) plus produced values |
+| `RuntimeCtx` | Holds the active `ScopedDict` and creates nested scopes |
+| `ScopedDict` | Maps SSA `Value`s to runtime values, falling back to parent scopes |
+| `ShapedArray` | Row-major array backing `memref` values |
+
+```mermaid
+flowchart LR
+    Module[ModuleOp] --> Interpreter
+    Interpreter --> Registry[(OpImpl registry)]
+    Interpreter --> Symbols[(Symbol table)]
+    Interpreter --> Ctx[RuntimeCtx]
+    Ctx --> Scope[ScopedDict]
+    Interpreter --> Main[call @main]
+    Main --> Result[Returned values]
+```
+
+### Adding an operation
+
+Implement `OpImpl` for the operation and register it in an `InterpreterDialect`:
+
+```scala
+import scair.interpreter.*
+import scair.dialects.arith
+
+object run_maxsi extends OpImpl[arith.MaxSI]:
+  def compute(
+      op: arith.MaxSI,
+      interpreter: Interpreter,
+      ctx: RuntimeCtx,
+      args: Seq[Any],
+  ): Seq[Any] =
+    args match
+      case Seq(lhs: Int, rhs: Int) => Seq(lhs.max(rhs))
+      case _ => throw new Exception("MaxSI operands must be integers")
+
+val extendedDialects =
+  allInterpreterDialects :+ Seq(run_maxsi)
+```
+
+Pass `extendedDialects` when constructing the interpreter:
+
+```scala
+val interpreter = new Interpreter(module, extendedDialects)
+```
+
+Terminators follow the same pattern, but implement `OpTerminatorImpl` and return a `CFGStep` describing where control flow goes next:
+
+```scala
+object run_my_br extends OpTerminatorImpl[my.Br]:
+  def computeTerminator(
+      op: my.Br,
+      interpreter: Interpreter,
+      ctx: RuntimeCtx,
+      args: Seq[Any],
+  ): (CFGStep, Seq[Any]) =
+    (CFGStep.Jump(op.dest, args), Seq())
+```
+
+## Testing
+
+- Unit tests: `./mill interpreter.test` — runs the module's unit tests
+- Filecheck tests: `./mill filechecks` — runs the lit programs under `tests/filecheck/interpreter/`
+- Full pipeline: `./mill testAll`
+
+## Current limitations
+
+- Integer arithmetic only — no floats, index, vector, tensor, or complex values
+- `arith.constant` supports `IntegerAttr` only
+- Signedness is not modeled; signed and unsigned variants use Scala `Int` semantics
+- `memref` stores are limited to `Int` values
+- The entry point is fixed to `@main`
+- External calls are limited to the built-in `@print`
+
+## Layout
+
+```text
+interpreter/
+├── src/
+│   ├── Interpreter.scala          # engine and RuntimeCtx
+│   ├── InterpreterDialects.scala  # built-in dialect registry
+│   ├── ScopedDict.scala           # scoped SSA value storage
+│   ├── ShapedArray.scala          # memref backing store
+│   └── Dialects/
+│       ├── Arith.scala
+│       ├── Func.scala
+│       ├── LLVM.scala
+│       ├── Memref.scala
+│       └── scf.scala
+└── test/
+    └── src/
+        └── ToolsTest.scala
+```
+
+## UG4 Dissertation
+
+<!-- TODO: describe the UG4 dissertation this work was part of -->
+
+## Findings
+
+<!-- TODO: add the dissertation findings -->
+

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -4,27 +4,37 @@
 [![codecov](https://codecov.io/github/edin-dal/scair/graph/badge.svg?token=H3TBWG1YNT)](https://codecov.io/github/edin-dal/scair)
 [![license](https://img.shields.io/badge/license-Apache_2.0-blue)](https://github.com/edin-dal/scair/blob/main/LICENSE)
 
-ScaIR's extensible interpreter infrastructure for MLIR. Enables the high-level interpretation and execution of MLIR programs through its bookkeeping and execution engine, all without lowering. To fully accomodate the open-endedness of MLIR dialects, the tool allows for the extension of per-dialect and per-operation implementation logic.
+ScaIR's extensible interpreter infrastructure for MLIR. It enables high-level interpretation and execution of MLIR SSA programs (complete with its own bookkeeping and execution engine) without lowering. To accommodate the open-endedness of MLIR dialects, operation and dialect implementation logic can be extended by overriding the registry in `./interpreter/src/InterpreterDialects.scala`.
+
+## Contents
+
+- [Overview](#overview)
+- [Features](#features)
+- [Getting started](#getting-started)
+- [Supported operations](#supported-operations)
+- [UG4 dissertation](#ug4-dissertation)
+- [Evaluation](#evaluation)
+- [Current limitations](#current-limitations)
+- [How it works](#how-it-works)
+- [Testing](#testing)
+- [Layout](#layout)
 
 ## Overview
 
 The `interpreter` module adds an execution path to ScaIR. It is used by the `scair-run` command-line tool (defined in `tools/runTool`), which:
 
-1. parses an `.mlir` file or stdin,
-2. registers the available supported dialects
-3. invokes the interpreter on the `.mlir` file
-4. returns the result once execution is completed
+1. Parses an `.mlir` file or stdin.
+2. Registers the supported dialects from the extensible dialect registry (see [Adding an operation](#adding-an-operation)).
+3. Invokes the interpreter on the `.mlir` file.
+4. Returns the result once execution completes.
 
 ## Features
 
-- Direct MLIR-level execution of MLIR programs
+- Direct execution of MLIR programs, without lowering
 - Scoped SSA value tracking with parent-scope lookup
 - Structured and multi-block CFG control flow handling
-- Function calls, recursion, and a built-in `@print`
-- Extensible operation implementations via the `OpImpl` trait
-- Terminator dispatch via the `OpTerminatorImpl` trait
-- Extensible dialect implementations via the `InterpreterDialects` class
-- Supports the `arith`, `memref`, `scf` dialects among others
+- Core helper functions for implementation logic (e.g. `push_scope`, `get_values`)
+- Built-in support for the `arith`, `memref`, and `scf` dialects, among others
 
 ## Getting started
 
@@ -35,7 +45,7 @@ The `interpreter` module adds an execution path to ScaIR. It is used by the `sca
 
 ### Run a program
 
-Create `add.mlir`:
+Start by running `tests/filecheck/interpreter/arith/simpleadd.mlir` — it creates two constants and adds them:
 
 ```mlir
 builtin.module {
@@ -51,52 +61,22 @@ builtin.module {
 Run it from the repository root:
 
 ```bash
-./mill tools.runTool.run add.mlir
+./mill tools.runTool.run tests/filecheck/interpreter/arith/simpleadd.mlir
 ```
 
-Output:
+The interpreter parses the file, finds `func.func @main`, executes it, and prints the returned value:
 
 ```text
 Result: 58
 ```
 
-> [!IMPORTANT]
-> Execution always starts at `func.func @main`. If no `main` symbol exists, the interpreter fails with `Function main not found`.
+A few things to keep in mind when trying other programs:
 
-When no file argument is given, `scair-run` reads IR from stdin.
+- The interpreter can only execute the operations and dialects listed under [Supported operations](#supported-operations); anything else fails with an unsupported-operation error.
+- Execution always starts at `func.func @main`. If no `main` symbol exists, the interpreter fails with `Function main not found`.
+- If you don't pass a file argument, `scair-run` reads IR from stdin.
 
-## Examples
-
-### Loops and loop-carried values
-
-```mlir
-builtin.module {
-  func.func @main() -> (i32) {
-    %n    = "arith.constant"() <{value = 10 : i32}> : () -> i32
-    %lb   = "arith.constant"() <{value = 0 : i32}> : () -> i32
-    %step = "arith.constant"() <{value = 1 : i32}> : () -> i32
-
-    %a0   = "arith.constant"() <{value = 0 : i32}> : () -> i32
-    %b0   = "arith.constant"() <{value = 1 : i32}> : () -> i32
-
-    %a_res, %b_res = "scf.for"(%lb, %n, %step, %a0, %b0) ({
-    ^bb0(%iv: i32, %a: i32, %b: i32):
-      %next = "arith.addi"(%a, %b) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
-      "scf.yield"(%b, %next) : (i32, i32) -> ()
-    }) : (i32, i32, i32, i32, i32) -> (i32, i32)
-
-    %fib_n = "arith.addi"(%a_res, %lb) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
-
-    func.return %fib_n : i32
-  }
-}
-```
-
-```text
-Result: 55
-```
-
-See examples of more complete programs in `tests/filecheck/interpreter/`.
+More complete programs can be found under `tests/filecheck/interpreter/`.
 
 ## Supported operations
 
@@ -107,6 +87,85 @@ See examples of more complete programs in `tests/filecheck/interpreter/`.
 | `memref` | `alloc`, `load`, `store` | backed by `ShapedArray` |
 | `scf` | `for`, `if`, `yield` | loop-carried values supported |
 | LLVM terminators | `llvm.br`, `llvm.cond_br`, `llvm.return`, `llvm.unreachable` | drive multi-block control flow; `llvm.return` returns from the function |
+
+## UG4 dissertation
+
+This work was developed as part of a UG4 dissertation on high-level interpretation of MLIR. The key dissertation findings, comparing this interpreter to xDSL's, a python-based compiler framework, are summarised below.
+
+### Findings
+
+- The interpreter allows for more conciseness when defining operations compared to xDSL: up to 28.8% fewer LoC (Arith), 18.8% fewer for MemRef (see [Evaluation](#evaluation) below).
+- Faster than xDSL on all four loop-based benchmark programs at their largest size, e.g. 1M looped function calls and iterative Fibonacci up to N = 1M (see [Evaluation](#evaluation) below).
+
+## Evaluation
+
+Comparative evaluation of ScaIR vs xDSL on implementation conciseness and runtime performance.
+
+### Implementation conciseness
+
+LoC to implement operation semantics (core logic only, no boilerplate):
+
+| Dialect | Framework | # of Ops | Total LoC | Avg LoC per Op | % Reduction (ScaIR vs xDSL) |
+| --- | --- | --- | --- | --- | --- |
+| Arith | ScaIR | 12 | 42 | 3.50 | 28.8% |
+| Arith | xDSL | 12 | 59 | 4.92 | — |
+| Func | ScaIR | 2 | 2 | 1.00 | 0.0% |
+| Func | xDSL | 2 | 2 | 1.00 | — |
+| MemRef | ScaIR | 3 | 13 | 4.34 | 18.8% |
+| MemRef | xDSL | 3 | 16 | 5.34 | — |
+| SCF | ScaIR | 2 | 8 | 4.00 | 0.0% |
+| SCF | xDSL | 2 | 8 | 4.00 | — |
+
+ScaIR matches or beats xDSL LoC on every dialect (28.8% fewer for Arith, 18.8% for MemRef, equal for Func/SCF) while adding compile-time type safety.
+
+### Runtime performance
+
+Average (mean) wall-clock seconds over 10 runs for each benchmark at its largest size (1M looped function calls, 1M load-add-store iterations, Fibonacci to N = 1M, and 10k chained additions):
+
+| Benchmark | Size | xDSL (s) | ScaIR (s) |
+| --- | --- | --- | --- |
+| func_calls | 1000000 | 16.164 | 0.888 |
+| memref | 1000000 | 14.729 | 0.993 |
+| fib | 1000000 | 8.143 | 0.664 |
+| chained_arith | 10000 | 1.120 | 0.722 |
+
+ScaIR interpreted beats xDSL on every benchmark at its largest size: 18× faster on 1M looped function calls, 15× on 1M load-add-store iterations, 12× on Fibonacci to N = 1M, and 1.5× on 10k chained additions. Benchmarked on an Apple M5 MacBook Pro (2026).
+
+All three looped benchmarks (`func_calls`, `memref`, `fib`) scale the same way, so `func_calls` is shown as a representative alongside the straight-line `chained_arith`.
+
+<details>
+<summary>Average runtime (s) across all benchmarked sizes</summary>
+
+The titles use the example program names from `tests/filecheck/interpreter/full-programs/` (`func_calls.mlir`, `fib.mlir`, `memref_tester.mlir`; `chained_arith` is generated by `chained_arith.py`). Key: in both charts the line ending higher at the largest size is xDSL; the lower line is ScaIR.
+
+```mermaid
+xychart-beta
+    title "func_calls — average runtime (s)"
+    x-axis ["10", "100", "1k", "10k", "100k", "1M"]
+    y-axis "average seconds" 0 --> 17
+    line "ScaIR" [0.249, 0.255, 0.273, 0.315, 0.419, 0.888]
+    line "xDSL" [0.194, 0.197, 0.190, 0.333, 1.764, 16.164]
+```
+
+```mermaid
+xychart-beta
+    title "chained_arith — average runtime (s)"
+    x-axis ["10", "20", "50", "100", "200", "500", "1k", "2k", "5k", "10k"]
+    y-axis "average seconds" 0 --> 1.2
+    line "ScaIR" [0.217, 0.219, 0.225, 0.235, 0.252, 0.284, 0.330, 0.401, 0.514, 0.722]
+    line "xDSL" [0.177, 0.178, 0.182, 0.187, 0.196, 0.225, 0.270, 0.363, 0.643, 1.120]
+```
+
+</details>
+
+## Current limitations
+
+- Integer arithmetic only — no floats, index, vector, tensor, or complex values
+- `arith.constant` supports `IntegerAttr` only
+- Signedness is not modeled; signed and unsigned variants use Scala `Int` semantics
+- `memref` stores are limited to `Int` values
+- The entry point is fixed to `@main`
+- External calls are limited to the built-in `@print`
 
 ## How it works
 
@@ -172,20 +231,40 @@ object run_my_br extends OpTerminatorImpl[my.Br]:
     (CFGStep.Jump(op.dest, args), Seq())
 ```
 
+### Adding a dialect
+
+An `InterpreterDialect` is a sequence of operation and terminator implementations:
+
+```scala
+type InterpreterDialect =
+  Seq[OpImpl[? <: Operation] | OpTerminatorImpl[? <: Operation]]
+```
+
+There is no separate dialect class to implement — a dialect is just the impls grouped together:
+
+```scala
+val myDialect: InterpreterDialect = Seq(run_maxsi, run_my_br)
+```
+
+As with dialect registration for ScaIR tools, there are two common ways to make it available to the interpreter:
+
+* When using ScaIR as a library: extend `ScairRunBase` (in `scair.tools.runTool`) and override `interpreterDialects` to append your dialect:
+
+```scala
+object MyRun extends ScairRunBase:
+  override def interpreterDialects =
+    scair.interpreter.allInterpreterDialects :+ myDialect
+```
+
+* When working within ScaIR itself: add the dialect to `allInterpreterDialects` in `interpreter/src/InterpreterDialects.scala`.
+
+The interpreter is then constructed with the extended list, as shown in [Adding an operation](#adding-an-operation).
+
 ## Testing
 
 - Unit tests: `./mill interpreter.test` — runs the module's unit tests
 - Filecheck tests: `./mill filechecks` — runs the lit programs under `tests/filecheck/interpreter/`
-- Full pipeline: `./mill testAll`
-
-## Current limitations
-
-- Integer arithmetic only — no floats, index, vector, tensor, or complex values
-- `arith.constant` supports `IntegerAttr` only
-- Signedness is not modeled; signed and unsigned variants use Scala `Int` semantics
-- `memref` stores are limited to `Int` values
-- The entry point is fixed to `@main`
-- External calls are limited to the built-in `@print`
+- Full pipeline: `./mill testAll` — runs the full ScaIR test suite, including this module
 
 ## Layout
 
@@ -206,12 +285,3 @@ interpreter/
     └── src/
         └── ToolsTest.scala
 ```
-
-## UG4 Dissertation
-
-<!-- TODO: describe the UG4 dissertation this work was part of -->
-
-## Findings
-
-<!-- TODO: add the dissertation findings -->
-

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -4,39 +4,30 @@
 [![codecov](https://codecov.io/github/edin-dal/scair/graph/badge.svg?token=H3TBWG1YNT)](https://codecov.io/github/edin-dal/scair)
 [![license](https://img.shields.io/badge/license-Apache_2.0-blue)](https://github.com/edin-dal/scair/blob/main/LICENSE)
 
-ScaIR's extensible interpreter infrastructure for MLIR. It enables high-level interpretation and execution of MLIR SSA programs (complete with its own bookkeeping and execution engine) without lowering. To accommodate the open-endedness of MLIR dialects, operation and dialect implementation logic can be extended by overriding the registry in `./interpreter/src/InterpreterDialects.scala`.
+ScaIR's extensible interpreter infrastructure for MLIR. It executes MLIR SSA programs directly (with its own scoping, bookkeeping, and execution engine) without lowering. Operation and dialect behaviour can be extended by registering implementations in the interpreter registry (`interpreter/src/InterpreterDialects.scala`).
+
+This module is part of [ScaIR](https://github.com/edin-dal/scair); see the [root README](../README.md) for the framework overview.
 
 ## Contents
 
-- [Overview](#overview)
-- [Features](#features)
 - [Getting started](#getting-started)
 - [Supported operations](#supported-operations)
-- [UG4 dissertation](#ug4-dissertation)
-- [Evaluation](#evaluation)
-- [Current limitations](#current-limitations)
 - [How it works](#how-it-works)
+- [Extending the interpreter](#extending-the-interpreter)
+- [Current limitations](#current-limitations)
 - [Testing](#testing)
 - [Layout](#layout)
+- [Background](#background)
+- [Evaluation](#evaluation)
 
-## Overview
+## Getting started
 
-The `interpreter` module adds an execution path to ScaIR. It is used by the `scair-run` command-line tool (defined in `tools/runTool`), which:
+The `interpreter` module adds an execution path to ScaIR, exposed through the `scair-run` command-line tool (defined in `tools/runTool`). `scair-run`:
 
 1. Parses an `.mlir` file or stdin.
 2. Registers the supported dialects from the extensible dialect registry (see [Adding an operation](#adding-an-operation)).
 3. Invokes the interpreter on the `.mlir` file.
 4. Returns the result once execution completes.
-
-## Features
-
-- Direct execution of MLIR programs, without lowering
-- Scoped SSA value tracking with parent-scope lookup
-- Structured and multi-block CFG control flow handling
-- Core helper functions for implementation logic (e.g. `push_scope`, `get_values`)
-- Built-in support for the `arith`, `memref`, and `scf` dialects, among others
-
-## Getting started
 
 ### Prerequisites
 
@@ -88,14 +79,119 @@ More complete programs can be found under `tests/filecheck/interpreter/`.
 | `scf` | `for`, `if`, `yield` | loop-carried values supported |
 | LLVM terminators | `llvm.br`, `llvm.cond_br`, `llvm.return`, `llvm.unreachable` | drive multi-block control flow; `llvm.return` returns from the function |
 
-## UG4 dissertation
+## How it works
 
-This work was developed as part of a UG4 dissertation on high-level interpretation of MLIR. The key dissertation findings, comparing this interpreter to xDSL's, a python-based compiler framework, are summarised below.
+| Component | Responsibility |
+| --- | --- |
+| `Interpreter` | Walks the module, dispatches operations, maintains the symbol table |
+| `OpImpl` | Per-operation implementation: `compute` returns results, which are stored in the current context |
+| Symbol Table | Mapping of all symbols (`global`, `func.func` names) for referencing |
+| `RuntimeCtx` | Holds the active `ScopedDict` and current region result |
+| `ScopedDict` | Maps SSA `Value`s to runtime values |
 
-### Findings
+```mermaid
+flowchart LR
+    Module[Input ModuleOp] --> Interpreter
+    Registry[(OpImpl registry)] --> Interpreter
+    Symbols[(Symbol Table)] --> Interpreter
+    Interpreter <--> Ctx[RuntimeCtx]
+    Interpreter --> Main[run @main]
+    Main --> Result[Return values]
+```
 
-- The interpreter allows for more conciseness when defining operations compared to xDSL: up to 28.8% fewer LoC (Arith), 18.8% fewer for MemRef (see [Evaluation](#evaluation) below).
-- Faster than xDSL on all four loop-based benchmark programs at their largest size, e.g. 1M looped function calls and iterative Fibonacci up to N = 1M (see [Evaluation](#evaluation) below).
+## Extending the interpreter
+
+During execution, the interpreter dispatches every operation to an `OpImpl`, the class that represents the high-level interpretation logic for that operation. To allow custom operations and dialects to be interpreted, the extension flow is: implement an `OpImpl`, group implementations into a dialect, register the dialect, and pass the extended registry to the interpreter.
+
+### Adding an operation
+
+Extend `OpImpl` for the operation of interest:
+
+```scala
+import scair.interpreter.*
+import scair.dialects.arith
+
+object run_maxsi extends OpImpl[arith.MaxSI]:
+  def compute(
+      op: arith.MaxSI,
+      interpreter: Interpreter,
+      ctx: RuntimeCtx,
+      args: Seq[Any],
+  ): Seq[Any] =
+    args match
+      case Seq(lhs: Int, rhs: Int) => Seq(lhs.max(rhs)) // must return seq()
+      case _ => throw new Exception("MaxSI operands must be integers")
+```
+
+### Adding a dialect
+
+An `InterpreterDialect` is a sequence of operation and terminator implementations:
+
+```scala
+type InterpreterDialect =
+  Seq[OpImpl[? <: Operation] | OpTerminatorImpl[? <: Operation]]
+```
+
+There is no separate dialect class to implement — a dialect is just the impls grouped together:
+
+```scala
+val myDialect: InterpreterDialect = Seq(run_maxsi, run_my_br)
+```
+
+### Registering the dialect
+
+As with dialect registration for ScaIR tools, there are two common ways to make your dialect available to the interpreter:
+
+* When using ScaIR as a library: extend `ScairRunBase` (in `scair.tools.runTool`) and override `interpreterDialects` to append your dialect:
+
+```scala
+object MyRun extends ScairRunBase:
+  override def interpreterDialects =
+    scair.interpreter.allInterpreterDialects :+ myDialect
+```
+
+* When working within ScaIR itself: add the dialect to `allInterpreterDialects` in `interpreter/src/InterpreterDialects.scala`.
+
+### Passing dialects to the interpreter
+
+Construct the interpreter with the extended dialect list:
+
+```scala
+val extendedDialects =
+  allInterpreterDialects :+ myDialect
+
+val interpreter = new Interpreter(module, extendedDialects)
+```
+
+## Current limitations
+
+- Integer arithmetic only — no floats, index, vector, tensor, or complex values
+- `arith.constant` supports `IntegerAttr` only
+- Signedness is not modeled; signed and unsigned variants use Scala `Int` semantics
+- `memref` stores are limited to `Int` values
+- The entry point is fixed to `@main`
+- External calls are limited to the built-in `@print`
+
+## Layout
+
+```text
+interpreter/
+└── src/
+    ├── Interpreter.scala          # engine and RuntimeCtx
+    ├── InterpreterDialects.scala  # built-in dialect registry
+    ├── ScopedDict.scala           # scoped SSA value storage
+    ├── ShapedArray.scala          # Reusable data type for tensors
+    └── Dialects/                  # ScaIR dialect implementations
+        ├── Arith.scala
+        ├── Func.scala
+        ├── LLVM.scala
+        ├── Memref.scala
+        └── scf.scala
+```
+
+## Background
+
+This module was developed as part of a UG4 dissertation on high-level interpretation of MLIR, which compared this interpreter to xDSL, a Python-based compiler framework. The headline results on implementation conciseness and runtime performance are detailed in the [Evaluation](#evaluation) below.
 
 ## Evaluation
 
@@ -131,10 +227,9 @@ Average (mean) wall-clock seconds over 10 runs for each benchmark at its largest
 
 ScaIR interpreted beats xDSL on every benchmark at its largest size: 18× faster on 1M looped function calls, 15× on 1M load-add-store iterations, 12× on Fibonacci to N = 1M, and 1.5× on 10k chained additions. Benchmarked on an Apple M5 MacBook Pro (2026).
 
-All three looped benchmarks (`func_calls`, `memref`, `fib`) scale the same way, so `func_calls` is shown as a representative alongside the straight-line `chained_arith`.
+### Full scaling charts
 
-<details>
-<summary>Average runtime (s) across all benchmarked sizes</summary>
+All three looped benchmarks (`func_calls`, `memref`, `fib`) scale the same way, so `func_calls` is representative of them all.
 
 The titles use the example program names from `tests/filecheck/interpreter/full-programs/` (`func_calls.mlir`, `fib.mlir`, `memref_tester.mlir`; `chained_arith` is generated by `chained_arith.py`). Key: in both charts the line ending higher at the largest size is xDSL; the lower line is ScaIR.
 
@@ -154,134 +249,4 @@ xychart-beta
     y-axis "average seconds" 0 --> 1.2
     line "ScaIR" [0.217, 0.219, 0.225, 0.235, 0.252, 0.284, 0.330, 0.401, 0.514, 0.722]
     line "xDSL" [0.177, 0.178, 0.182, 0.187, 0.196, 0.225, 0.270, 0.363, 0.643, 1.120]
-```
-
-</details>
-
-## Current limitations
-
-- Integer arithmetic only — no floats, index, vector, tensor, or complex values
-- `arith.constant` supports `IntegerAttr` only
-- Signedness is not modeled; signed and unsigned variants use Scala `Int` semantics
-- `memref` stores are limited to `Int` values
-- The entry point is fixed to `@main`
-- External calls are limited to the built-in `@print`
-
-## How it works
-
-| Component | Responsibility |
-| --- | --- |
-| `Interpreter` | Walks the module, dispatches operations, maintains the symbol table |
-| `OpImpl` | Per-operation implementation: `compute` returns results, which are stored in the current context |
-| `OpTerminatorImpl` | Terminator implementation: returns a `CFGStep` (jump to a block or return) plus produced values |
-| `RuntimeCtx` | Holds the active `ScopedDict` and creates nested scopes |
-| `ScopedDict` | Maps SSA `Value`s to runtime values, falling back to parent scopes |
-| `ShapedArray` | Row-major array backing `memref` values |
-
-```mermaid
-flowchart LR
-    Module[ModuleOp] --> Interpreter
-    Interpreter --> Registry[(OpImpl registry)]
-    Interpreter --> Symbols[(Symbol table)]
-    Interpreter --> Ctx[RuntimeCtx]
-    Ctx --> Scope[ScopedDict]
-    Interpreter --> Main[call @main]
-    Main --> Result[Returned values]
-```
-
-### Adding an operation
-
-Implement `OpImpl` for the operation and register it in an `InterpreterDialect`:
-
-```scala
-import scair.interpreter.*
-import scair.dialects.arith
-
-object run_maxsi extends OpImpl[arith.MaxSI]:
-  def compute(
-      op: arith.MaxSI,
-      interpreter: Interpreter,
-      ctx: RuntimeCtx,
-      args: Seq[Any],
-  ): Seq[Any] =
-    args match
-      case Seq(lhs: Int, rhs: Int) => Seq(lhs.max(rhs))
-      case _ => throw new Exception("MaxSI operands must be integers")
-
-val extendedDialects =
-  allInterpreterDialects :+ Seq(run_maxsi)
-```
-
-Pass `extendedDialects` when constructing the interpreter:
-
-```scala
-val interpreter = new Interpreter(module, extendedDialects)
-```
-
-Terminators follow the same pattern, but implement `OpTerminatorImpl` and return a `CFGStep` describing where control flow goes next:
-
-```scala
-object run_my_br extends OpTerminatorImpl[my.Br]:
-  def computeTerminator(
-      op: my.Br,
-      interpreter: Interpreter,
-      ctx: RuntimeCtx,
-      args: Seq[Any],
-  ): (CFGStep, Seq[Any]) =
-    (CFGStep.Jump(op.dest, args), Seq())
-```
-
-### Adding a dialect
-
-An `InterpreterDialect` is a sequence of operation and terminator implementations:
-
-```scala
-type InterpreterDialect =
-  Seq[OpImpl[? <: Operation] | OpTerminatorImpl[? <: Operation]]
-```
-
-There is no separate dialect class to implement — a dialect is just the impls grouped together:
-
-```scala
-val myDialect: InterpreterDialect = Seq(run_maxsi, run_my_br)
-```
-
-As with dialect registration for ScaIR tools, there are two common ways to make it available to the interpreter:
-
-* When using ScaIR as a library: extend `ScairRunBase` (in `scair.tools.runTool`) and override `interpreterDialects` to append your dialect:
-
-```scala
-object MyRun extends ScairRunBase:
-  override def interpreterDialects =
-    scair.interpreter.allInterpreterDialects :+ myDialect
-```
-
-* When working within ScaIR itself: add the dialect to `allInterpreterDialects` in `interpreter/src/InterpreterDialects.scala`.
-
-The interpreter is then constructed with the extended list, as shown in [Adding an operation](#adding-an-operation).
-
-## Testing
-
-- Unit tests: `./mill interpreter.test` — runs the module's unit tests
-- Filecheck tests: `./mill filechecks` — runs the lit programs under `tests/filecheck/interpreter/`
-- Full pipeline: `./mill testAll` — runs the full ScaIR test suite, including this module
-
-## Layout
-
-```text
-interpreter/
-├── src/
-│   ├── Interpreter.scala          # engine and RuntimeCtx
-│   ├── InterpreterDialects.scala  # built-in dialect registry
-│   ├── ScopedDict.scala           # scoped SSA value storage
-│   ├── ShapedArray.scala          # memref backing store
-│   └── Dialects/
-│       ├── Arith.scala
-│       ├── Func.scala
-│       ├── LLVM.scala
-│       ├── Memref.scala
-│       └── scf.scala
-└── test/
-    └── src/
-        └── ToolsTest.scala
 ```

--- a/interpreter/src/Dialects/Func.scala
+++ b/interpreter/src/Dialects/Func.scala
@@ -4,15 +4,15 @@ import scair.dialects.builtin.SymbolRefAttr
 import scair.dialects.func
 import scair.ir.Result
 
-object run_return extends OpImpl[func.Return]:
+object run_return extends OpTerminatorImpl[func.Return]:
 
-  def compute(
+  def computeTerminator(
       op: func.Return,
       interpreter: Interpreter,
       ctx: RuntimeCtx,
       args: Seq[Any],
-  ): Seq[Any] =
-    return args
+  ): (CFGStep, Seq[Any]) =
+    (CFGStep.Return(args), Seq())
 
 object run_call extends OpImpl[func.Call]:
 
@@ -44,7 +44,7 @@ object run_function extends OpImpl[func.Func]:
       _operands = Seq(),
       _results = op.function_type.outputs.map(res => Result(res)),
     )
-    val results = interpreter.run_op(new_call, ctx, Seq())
+    val results = interpreter.run_op(new_call, ctx, Seq()).values
 
     if new_call._results.nonEmpty then results
     else Seq()

--- a/interpreter/src/Dialects/LLVM.scala
+++ b/interpreter/src/Dialects/LLVM.scala
@@ -1,0 +1,58 @@
+package scair.interpreter
+
+import scair.dialects.llvm
+
+object run_llvm_br extends OpTerminatorImpl[llvm.Br]:
+
+  def computeTerminator(
+      op: llvm.Br,
+      interpreter: Interpreter,
+      ctx: RuntimeCtx,
+      args: Seq[Any],
+  ): (CFGStep, Seq[Any]) =
+    (CFGStep.Jump(op.dest, args), Seq())
+
+object run_llvm_cond_br extends OpTerminatorImpl[llvm.CondBr]:
+
+  def computeTerminator(
+      op: llvm.CondBr,
+      interpreter: Interpreter,
+      ctx: RuntimeCtx,
+      args: Seq[Any],
+  ): (CFGStep, Seq[Any]) =
+    args match
+      case cond +: rest =>
+        val (trueArgs, falseArgs) = rest.splitAt(op.trueArgs.size)
+        val taken = cond match
+          case true => true
+          case 1    => true
+          case _    => false
+        val step =
+          if taken then CFGStep.Jump(op.trueDest, trueArgs)
+          else CFGStep.Jump(op.falseDest, falseArgs)
+        (step, Seq())
+      case _ =>
+        throw new Exception("llvm.cond_br requires a condition operand")
+
+object run_llvm_return extends OpTerminatorImpl[llvm.Return]:
+
+  def computeTerminator(
+      op: llvm.Return,
+      interpreter: Interpreter,
+      ctx: RuntimeCtx,
+      args: Seq[Any],
+  ): (CFGStep, Seq[Any]) =
+    (CFGStep.Return(args), Seq())
+
+object run_llvm_unreachable extends OpTerminatorImpl[llvm.Unreachable]:
+
+  def computeTerminator(
+      op: llvm.Unreachable,
+      interpreter: Interpreter,
+      ctx: RuntimeCtx,
+      args: Seq[Any],
+  ): (CFGStep, Seq[Any]) =
+    throw new Exception("llvm.unreachable executed")
+
+val InterpreterLLVMDialect: InterpreterDialect =
+  Seq(run_llvm_br, run_llvm_cond_br, run_llvm_return, run_llvm_unreachable)

--- a/interpreter/src/Dialects/scf.scala
+++ b/interpreter/src/Dialects/scf.scala
@@ -71,15 +71,15 @@ object run_if extends OpImpl[scf.IfOp]:
       case _ =>
         throw new Exception("If condition must be an integer")
 
-object run_yield extends OpImpl[scf.YieldOp]:
+object run_yield extends OpTerminatorImpl[scf.YieldOp]:
 
-  def compute(
+  def computeTerminator(
       op: scf.YieldOp,
       interpreter: Interpreter,
       ctx: RuntimeCtx,
       args: Seq[Any],
-  ): Seq[Any] =
-    args
+  ): (CFGStep, Seq[Any]) =
+    (CFGStep.Return(args), Seq())
 
 val InterpreterScfDialect: InterpreterDialect =
   Seq(

--- a/interpreter/src/Interpreter.scala
+++ b/interpreter/src/Interpreter.scala
@@ -7,10 +7,21 @@ import scala.collection.mutable
 import scala.reflect.ClassTag
 
 // global implementation dictionary for interpreter
-val impl_dict = mutable
-  .Map[Class[? <: Operation], OpImpl[
-    ? <: Operation
-  ]]()
+type RegisteredImpl =
+  (Interpreter, RuntimeCtx, Operation, Seq[Any]) => OpImplResult
+
+val impl_dict = mutable.Map[Class[? <: Operation], RegisteredImpl]()
+
+// control-flow step produced by a terminator implementation
+enum CFGStep:
+  case Return(values: Seq[Any])
+  case Jump(dest: Block, args: Seq[Any])
+
+// result of running an operation: produced values plus optional control-flow step
+case class OpImplResult(
+    values: Seq[Any],
+    step: Option[CFGStep] = None,
+)
 
 // custom operations should implement this trait
 trait OpImpl[O <: Operation: ClassTag]:
@@ -28,22 +39,18 @@ trait OpImpl[O <: Operation: ClassTag]:
       args: Seq[Any],
   ): Seq[Any]
 
-  // run function that is automatically defined to store results in context after compute
-  final def run(op: O, interpreter: Interpreter, ctx: RuntimeCtx): Unit =
-    var args = interpreter.get_values(op.operands, ctx)
+// terminator operations implement this trait instead of OpImpl
+// computeTerminator returns the control-flow step to take, plus any values the operation produces
+trait OpTerminatorImpl[O <: Operation: ClassTag]:
 
-    // call compute to get result
-    val result = compute(op, interpreter, ctx, args)
-    val op_results = op.results
+  def opType: Class[O] = summon[ClassTag[O]].runtimeClass.asInstanceOf[Class[O]]
 
-    if op_results.size == 0 then ()
-    else if op_results.size == 1 then
-      ctx.scopedDict.update(op_results.head, result.head)
-    else
-      var i = 0
-      while i < op_results.length do
-        ctx.scopedDict.update(op_results(i), result(i))
-        i += 1
+  def computeTerminator(
+      op: O,
+      interpreter: Interpreter,
+      ctx: RuntimeCtx,
+      args: Seq[Any],
+  ): (CFGStep, Seq[Any])
 
 // interpreter context class stores variables and current result
 class RuntimeCtx(
@@ -112,26 +119,31 @@ class Interpreter(
 
   def register_implementations(): Unit =
     for dialect <- dialects do
-      for impl <- dialect do impl_dict.put(impl.opType, impl)
+      for impl <- dialect do
+        impl match
+          case opImpl: OpImpl[? <: Operation] =>
+            impl_dict.put(
+              opImpl.opType,
+              (interp, ctx, op, args) =>
+                OpImplResult(
+                  opImpl
+                    .asInstanceOf[OpImpl[Operation]]
+                    .compute(op, interp, ctx, args)
+                ),
+            )
+          case termImpl: OpTerminatorImpl[? <: Operation] =>
+            impl_dict.put(
+              termImpl.opType,
+              (interp, ctx, op, args) =>
+                val (step, values) =
+                  termImpl
+                    .asInstanceOf[OpTerminatorImpl[Operation]]
+                    .computeTerminator(op, interp, ctx, args)
+                OpImplResult(values, Some(step)),
+            )
 
   def create_scope(name: String): RuntimeCtx =
     RuntimeCtx(ScopedDict(None, mutable.Map(), name), Seq())
-
-  def interpret_op(op: Operation, ctx: RuntimeCtx): Unit =
-    val impl = impl_dict.get(op.getClass)
-    impl match
-      case Some(impl) => impl.asInstanceOf[OpImpl[Operation]].run(op, this, ctx)
-      case None       =>
-        throw new Exception(
-          s"Unsupported operation when interpreting: ${op.getClass}"
-        )
-
-  def interpret_region(region: Region, ctx: RuntimeCtx): Unit =
-    for operation <- region.blocks.head.operations do
-      interpret_op(operation, ctx)
-
-  def interpret_block(block: Block, ctx: RuntimeCtx): Unit =
-    for operation <- block.operations do interpret_op(operation, ctx)
 
   def run_ssacfg_region(
       region: Region,
@@ -139,29 +151,60 @@ class Interpreter(
       name: String,
       inputs: Seq[Any],
   ): Seq[Any] =
-    var results: Seq[Any] = Seq()
+    if region.blocks.isEmpty then return Seq()
 
-    if region.blocks.isEmpty then return Seq() // no blocks to run
-    else
-      val new_ctx = ctx.push_scope(name)
-      set_values(region.blocks.head.arguments, inputs, new_ctx)
-      for operation <- region.blocks.head.operations do
-        val inputs = get_values(operation.operands, new_ctx)
-        if operation.isInstanceOf[IsTerminator] then
-          results = run_op(operation, new_ctx, inputs)
-        interpret_op(operation, new_ctx)
-      results
+    var current: Option[Block] = Some(region.blocks.head)
+    var blockArgs = inputs
+    var blockCtx = ctx.push_scope(name)
 
-  def run_op(op: Operation, ctx: RuntimeCtx, inputs: Seq[Any]): Seq[Any] =
+    while current.isDefined do
+      val block = current.get
+      current = None
+      bind_block_args(block, blockArgs, blockCtx)
+
+      var jump: Option[(Block, Seq[Any])] = None
+      val ops = block.operations.toSeq
+      var i = 0
+      while i < ops.length && jump.isEmpty do
+        val op = ops(i)
+        val res = run_op(op, blockCtx, get_values(op.operands, blockCtx))
+        set_values(op.results, res.values, blockCtx)
+        res.step match
+          case Some(CFGStep.Return(values)) => return values
+          case Some(CFGStep.Jump(dest, args)) =>
+            jump = Some((dest, args))
+          case None => ()
+        i += 1
+
+      jump match
+        case Some((dest, args)) =>
+          current = Some(dest)
+          blockArgs = args
+          blockCtx = blockCtx.push_scope(name)
+        case None => ()
+    Seq()
+
+  private def bind_block_args(
+      block: Block,
+      args: Seq[Any],
+      ctx: RuntimeCtx,
+  ): Unit =
+    if block.arguments.size != args.size then
+      throw new Exception(
+        s"Expected ${block.arguments.size} block arguments, got ${args.size}"
+      )
+    set_values(block.arguments, args, ctx)
+
+  def run_op(op: Operation, ctx: RuntimeCtx, inputs: Seq[Any]): OpImplResult =
     val impl = impl_dict.get(op.getClass)
     impl match
       case Some(impl) =>
-        impl.asInstanceOf[OpImpl[Operation]].compute(
-          op,
-          this,
-          ctx,
-          inputs,
-        )
+        val res = impl(this, ctx, op, inputs)
+        if op.results.size != res.values.size then
+          throw new Exception(
+            s"Operation '${op.name}' produced ${res.values.size} values but declares ${op.results.size} results"
+          )
+        res
       case None =>
         throw new Exception(
           s"Unsupported operation when interpreting: ${op.getClass}"

--- a/interpreter/src/Interpreter.scala
+++ b/interpreter/src/Interpreter.scala
@@ -126,8 +126,7 @@ class Interpreter(
               opImpl.opType,
               (interp, ctx, op, args) =>
                 OpImplResult(
-                  opImpl
-                    .asInstanceOf[OpImpl[Operation]]
+                  opImpl.asInstanceOf[OpImpl[Operation]]
                     .compute(op, interp, ctx, args)
                 ),
             )
@@ -136,8 +135,7 @@ class Interpreter(
               termImpl.opType,
               (interp, ctx, op, args) =>
                 val (step, values) =
-                  termImpl
-                    .asInstanceOf[OpTerminatorImpl[Operation]]
+                  termImpl.asInstanceOf[OpTerminatorImpl[Operation]]
                     .computeTerminator(op, interp, ctx, args)
                 OpImplResult(values, Some(step)),
             )
@@ -170,7 +168,7 @@ class Interpreter(
         val res = run_op(op, blockCtx, get_values(op.operands, blockCtx))
         set_values(op.results, res.values, blockCtx)
         res.step match
-          case Some(CFGStep.Return(values)) => return values
+          case Some(CFGStep.Return(values))   => return values
           case Some(CFGStep.Jump(dest, args)) =>
             jump = Some((dest, args))
           case None => ()
@@ -202,7 +200,8 @@ class Interpreter(
         val res = impl(this, ctx, op, inputs)
         if op.results.size != res.values.size then
           throw new Exception(
-            s"Operation '${op.name}' produced ${res.values.size} values but declares ${op.results.size} results"
+            s"Operation '${op.name}' produced ${res.values
+                .size} values but declares ${op.results.size} results"
           )
         res
       case None =>

--- a/interpreter/src/InterpreterDialects.scala
+++ b/interpreter/src/InterpreterDialects.scala
@@ -2,7 +2,8 @@ package scair.interpreter
 
 import scair.ir.*
 
-type InterpreterDialect = Seq[OpImpl[? <: Operation]]
+type InterpreterDialect =
+  Seq[OpImpl[? <: Operation] | OpTerminatorImpl[? <: Operation]]
 
 val allInterpreterDialects: Seq[InterpreterDialect] =
   Seq(
@@ -10,4 +11,5 @@ val allInterpreterDialects: Seq[InterpreterDialect] =
     InterpreterArithDialect,
     InterpreterMemrefDialect,
     InterpreterScfDialect,
+    InterpreterLLVMDialect,
   )

--- a/tests/filecheck/interpreter/multiblock/diamond.mlir
+++ b/tests/filecheck/interpreter/multiblock/diamond.mlir
@@ -1,0 +1,20 @@
+// RUN: scair-run %s | filecheck %s
+
+builtin.module {
+  func.func @main() -> (i32) {
+    %c3 = "arith.constant"() <{value = 3 : i32}> : () -> i32
+    %c7 = "arith.constant"() <{value = 7 : i32}> : () -> i32
+    %cond = "arith.cmpi"(%c7, %c3) <{"predicate" = 4 : i64}> : (i32, i32) -> i1
+    "llvm.cond_br"(%cond) [^then, ^else] <{operandSegmentSizes = array<i32: 1, 0, 0>}> : (i1) -> ()
+  ^then:
+    %t = "arith.muli"(%c3, %c7) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
+    "llvm.br"(%t) [^join] : (i32) -> ()
+  ^else:
+    %e = "arith.addi"(%c3, %c7) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
+    "llvm.br"(%e) [^join] : (i32) -> ()
+  ^join(%res : i32):
+    func.return %res : i32
+  }
+}
+
+// CHECK: Result: 21

--- a/tests/filecheck/interpreter/multiblock/loop_count.mlir
+++ b/tests/filecheck/interpreter/multiblock/loop_count.mlir
@@ -1,0 +1,20 @@
+// RUN: scair-run %s | filecheck %s
+
+builtin.module {
+  func.func @main() -> (i32) {
+    %c0 = "arith.constant"() <{value = 0 : i32}> : () -> i32
+    %c5 = "arith.constant"() <{value = 5 : i32}> : () -> i32
+    %c1 = "arith.constant"() <{value = 1 : i32}> : () -> i32
+    "llvm.br"(%c0) [^loop] : (i32) -> ()
+  ^loop(%i : i32):
+    %cond = "arith.cmpi"(%i, %c5) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
+    "llvm.cond_br"(%cond, %i, %i) [^body, ^exit] <{operandSegmentSizes = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
+  ^body(%j : i32):
+    %next = "arith.addi"(%j, %c1) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
+    "llvm.br"(%next) [^loop] : (i32) -> ()
+  ^exit(%k : i32):
+    func.return %k : i32
+  }
+}
+
+// CHECK: Result: 5

--- a/tests/filecheck/interpreter/multiblock/loop_sum.mlir
+++ b/tests/filecheck/interpreter/multiblock/loop_sum.mlir
@@ -1,0 +1,21 @@
+// RUN: scair-run %s | filecheck %s
+
+builtin.module {
+  func.func @main() -> (i32) {
+    %c1 = "arith.constant"() <{value = 1 : i32}> : () -> i32
+    %c0 = "arith.constant"() <{value = 0 : i32}> : () -> i32
+    %c6 = "arith.constant"() <{value = 6 : i32}> : () -> i32
+    "llvm.br"(%c1, %c0) [^loop] : (i32, i32) -> ()
+  ^loop(%i : i32, %acc : i32):
+    %cond = "arith.cmpi"(%i, %c6) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
+    "llvm.cond_br"(%cond, %i, %acc, %i, %acc) [^body, ^exit] <{operandSegmentSizes = array<i32: 1, 2, 2>}> : (i1, i32, i32, i32, i32) -> ()
+  ^body(%j : i32, %a : i32):
+    %next = "arith.addi"(%j, %c1) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
+    %sum = "arith.addi"(%a, %j) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
+    "llvm.br"(%next, %sum) [^loop] : (i32, i32) -> ()
+  ^exit(%k : i32, %s : i32):
+    func.return %s : i32
+  }
+}
+
+// CHECK: Result: 15

--- a/tests/filecheck/interpreter/multiblock/multifunc_blocks.mlir
+++ b/tests/filecheck/interpreter/multiblock/multifunc_blocks.mlir
@@ -1,0 +1,28 @@
+// RUN: scair-run %s | filecheck %s
+
+builtin.module {
+  func.func @double(%x: i32) -> i32 {
+    %c2 = "arith.constant"() <{value = 2 : i32}> : () -> i32
+    "llvm.br"(%x) [^body] : (i32) -> ()
+  ^body(%v : i32):
+    %res = "arith.muli"(%v, %c2) <{overflowFlags = #arith.overflow<none>}> : (i32, i32) -> i32
+    "llvm.br"(%res) [^exit] : (i32) -> ()
+  ^exit(%out : i32):
+    func.return %out : i32
+  }
+  func.func @main() -> (i32) {
+    %c21 = "arith.constant"() <{value = 21 : i32}> : () -> i32
+    %c0 = "arith.constant"() <{value = 0 : i32}> : () -> i32
+    %cond = "arith.cmpi"(%c21, %c0) <{"predicate" = 4 : i64}> : (i32, i32) -> i1
+    "llvm.cond_br"(%cond) [^call, ^skip] <{operandSegmentSizes = array<i32: 1, 0, 0>}> : (i1) -> ()
+  ^call:
+    %d = "func.call"(%c21) <{"callee" = @double}> : (i32) -> i32
+    "llvm.br"(%d) [^join] : (i32) -> ()
+  ^skip:
+    "llvm.br"(%c21) [^join] : (i32) -> ()
+  ^join(%res : i32):
+    func.return %res : i32
+  }
+}
+
+// CHECK: Result: 42

--- a/tests/filecheck/interpreter/multiblock/simple_br.mlir
+++ b/tests/filecheck/interpreter/multiblock/simple_br.mlir
@@ -1,0 +1,20 @@
+// RUN: scair-run %s | filecheck %s
+
+builtin.module {
+  func.func @main() -> (i32) {
+    %c10 = "arith.constant"() <{value = 10 : i32}> : () -> i32
+    %c20 = "arith.constant"() <{value = 20 : i32}> : () -> i32
+    %c1 = "arith.constant"() <{value = 1 : i32}> : () -> i32
+    %c2 = "arith.constant"() <{value = 2 : i32}> : () -> i32
+    %cond = "arith.cmpi"(%c1, %c2) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
+    "llvm.cond_br"(%cond) [^then, ^else] <{operandSegmentSizes = array<i32: 1, 0, 0>}> : (i1) -> ()
+  ^then:
+    "llvm.br"(%c10) [^join] : (i32) -> ()
+  ^else:
+    "llvm.br"(%c20) [^join] : (i32) -> ()
+  ^join(%res : i32):
+    func.return %res : i32
+  }
+}
+
+// CHECK: Result: 10


### PR DESCRIPTION
Added multi-block interpretation:
- OpTerminatorImpl class that also returns an optional CFGStep
- A general RegisteredImpl class that different Impl type of constructs in future can construct to for unified handling
- Changed run_ssacfg to execute blocks and choose the next one based off of the terminator and CFG step

Also added standalone readme for the interpreter section (for CV and presentability reasons)